### PR TITLE
fix recording finalization lifecycle

### DIFF
--- a/src/murmur/cli.py
+++ b/src/murmur/cli.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
-import signal
 from datetime import datetime
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -24,6 +22,7 @@ from murmur.recorder import (
     record_foreground,
     resolve_sink,
     resolve_source,
+    stop_recording,
 )
 
 console = Console()
@@ -267,14 +266,13 @@ def toggle(audio_format: str, tag: str | None, mic: bool, mic_device: int | None
 
     if pid is not None:
         try:
-            os.kill(pid, signal.SIGTERM)
-            notify("Recording stopped", "Meeting recording saved.")
-            console.print(f"[yellow]Stopped recording (PID {pid}).[/yellow]")
-        except ProcessLookupError:
-            from murmur.recorder import PID_FILE
-
-            PID_FILE.unlink(missing_ok=True)
-            console.print("[yellow]Recording was already stopped.[/yellow]")
+            finalized = stop_recording()
+        except RuntimeError as error:
+            console.print(f"[red]Could not stop recording: {error}[/red]")
+            raise click.ClickException(str(error)) from error
+        notify("Recording stopped", f"Saved {Path(finalized['output']).name}.")
+        console.print(f"[yellow]Stopped recording (PID {pid}).[/yellow]")
+        console.print(f"  Output: [cyan]{finalized['output']}[/cyan]")
         return
 
     sink_id, monitor_name = resolve_sink(None)

--- a/src/murmur/plugins/tui.py
+++ b/src/murmur/plugins/tui.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import signal
 from datetime import datetime
 from pathlib import Path
 
@@ -19,6 +18,7 @@ from murmur.recorder import (
     notify,
     record_background,
     resolve_sink,
+    stop_recording,
 )
 
 AUDIO_SUFFIXES = {".flac", ".mp3", ".wav", ".ogg", ".m4a", ".opus"}
@@ -355,11 +355,11 @@ def _build_app(audio_format: str):
                 self.notify("Not recording", severity="warning")
                 return
             try:
-                os.kill(pid, signal.SIGTERM)
+                finalized = stop_recording()
                 notify("Recording stopped", "Meeting recording saved.")
-                self.notify("Recording stopped")
-            except ProcessLookupError:
-                self.notify("Recording already stopped", severity="warning")
+                self.notify(f"Recording saved: {Path(finalized['output']).name}")
+            except RuntimeError as error:
+                self.notify(f"Could not stop recording: {error}", severity="error")
             # Table will refresh via poll or status bar detection
             self.set_timer(1.0, self._populate_table)
 

--- a/src/murmur/plugins/watch.py
+++ b/src/murmur/plugins/watch.py
@@ -16,6 +16,7 @@ from murmur.recorder import (
     notify,
     record_background,
     resolve_sink,
+    stop_recording,
 )
 
 console = Console()
@@ -211,14 +212,16 @@ def register(cli: click.Group) -> None:
                     )
 
                     if auto_record and is_recording():
-                        import os
-                        import signal
-
-                        pid = is_recording()
-                        if pid:
-                            os.kill(pid, signal.SIGTERM)
+                        try:
+                            finalized = stop_recording()
                             notify("Auto-recording stopped", "Meeting recording saved.")
-                            console.print("[bold yellow]Auto-recording stopped.[/bold yellow]")
+                            console.print(
+                                "[bold yellow]Auto-recording stopped:[/bold yellow] "
+                                f"{finalized['output']}"
+                            )
+                        except RuntimeError as error:
+                            notify("Could not stop recording", str(error), urgency="critical")
+                            console.print(f"[red]Could not stop recording: {error}[/red]")
 
                     active_meeting = None
 

--- a/src/murmur/recorder.py
+++ b/src/murmur/recorder.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
+import time
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from rich.console import Console
 
@@ -18,6 +23,215 @@ from murmur.config import get_section
 console = Console()
 
 PID_FILE = Path.home() / ".cache" / "murmur" / "murmur.pid"
+
+
+def _state_file() -> Path:
+    return PID_FILE.with_name("recording.json")
+
+
+def _lock_file() -> Path:
+    return PID_FILE.with_name("control.lock")
+
+
+@contextmanager
+def _control_lock():
+    """Serialize recording state transitions across CLI/plugin processes."""
+    lock_path = _lock_file()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        yield
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2) + "\n")
+    os.replace(temporary, path)
+
+
+def _read_active_state() -> dict[str, Any] | None:
+    try:
+        state = json.loads(_state_file().read_text())
+    except FileNotFoundError, json.JSONDecodeError, OSError:
+        return None
+    return state if isinstance(state, dict) else None
+
+
+def _clear_active_state() -> None:
+    PID_FILE.unlink(missing_ok=True)
+    _state_file().unlink(missing_ok=True)
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError, PermissionError:
+        return False
+
+    # kill(pid, 0) succeeds for zombies, but a zombie has already finished
+    # writing its output and should not block finalization.
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+        if stat.rsplit(")", 1)[1].strip().startswith("Z"):
+            return False
+    except FileNotFoundError, IndexError, OSError:
+        pass
+    return True
+
+
+def _process_matches(pid: int, output_path: str | None = None) -> bool:
+    """Return whether pid is the FFmpeg process recorded in active state."""
+    if not _pid_exists(pid):
+        return False
+    try:
+        command = Path(f"/proc/{pid}/cmdline").read_bytes().split(b"\0")
+    except FileNotFoundError, PermissionError, OSError:
+        return False
+    if not command or Path(os.fsdecode(command[0])).name != "ffmpeg":
+        return False
+    if output_path is None:
+        return True
+    encoded_output = os.fsencode(output_path)
+    return encoded_output in command
+
+
+def _recording_metadata(
+    output_path: Path,
+    monitor_name: str,
+    sink_id: int,
+    audio_format: str,
+    mic_source: str | None,
+    mic_id: int | None,
+) -> dict[str, Any]:
+    meta: dict[str, Any] = {
+        "status": "recording",
+        "source": f"{monitor_name}.monitor",
+        "sink_id": sink_id,
+        "format": audio_format,
+        "started_at": datetime.now().isoformat(),
+        "output": str(output_path),
+        "dual_channel": mic_source is not None,
+    }
+    if mic_source:
+        meta["mic_source"] = mic_source
+        meta["mic_id"] = mic_id
+    return meta
+
+
+def _write_active_state(pid: int, meta: dict[str, Any], log_path: Path) -> None:
+    PID_FILE.parent.mkdir(parents=True, exist_ok=True)
+    PID_FILE.write_text(f"{pid}\n")
+    _write_json_atomic(
+        _state_file(),
+        {
+            "pid": pid,
+            "output": meta["output"],
+            "meta_path": str(Path(meta["output"]).with_suffix(".json")),
+            "log_path": str(log_path),
+            "started_at": meta["started_at"],
+        },
+    )
+
+
+def _metadata_from_state(state: dict[str, Any]) -> dict[str, Any]:
+    output_path = Path(state["output"])
+    meta_path = Path(state.get("meta_path", output_path.with_suffix(".json")))
+    try:
+        meta = json.loads(meta_path.read_text())
+    except FileNotFoundError, json.JSONDecodeError, OSError:
+        meta = {
+            "status": "recording",
+            "started_at": state.get("started_at", datetime.now().isoformat()),
+            "output": str(output_path),
+        }
+    if isinstance(meta, dict):
+        return meta
+    return {"status": "recording", "output": str(output_path)}
+
+
+def _log_error(state: dict[str, Any]) -> str | None:
+    log_path = state.get("log_path")
+    if not log_path:
+        return None
+    try:
+        content = Path(log_path).read_text(errors="replace").strip()
+    except OSError:
+        return None
+    return content[-500:] or None
+
+
+def _mark_start_failed(meta: dict[str, Any], error: OSError) -> None:
+    failed = dict(meta)
+    failed.update(
+        {
+            "status": "failed",
+            "stopped_at": datetime.now().isoformat(),
+            "error": f"Could not start FFmpeg: {error}",
+        }
+    )
+    _write_json_atomic(Path(meta["output"]).with_suffix(".json"), failed)
+
+
+def _probe_media(output_path: Path) -> dict[str, Any] | None:
+    ffprobe = shutil.which("ffprobe")
+    if ffprobe is None:
+        return None
+    result = subprocess.run(  # noqa: S603
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration,size:stream=index,codec_name,codec_type,channels",
+            "-of",
+            "json",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _finalize_recording(meta: dict[str, Any], error: str | None = None) -> dict[str, Any]:
+    output_path = Path(meta["output"])
+    meta_path = output_path.with_suffix(".json")
+    finalized = dict(meta)
+    finalized["stopped_at"] = datetime.now().isoformat()
+
+    probe = _probe_media(output_path) if output_path.is_file() else None
+    if probe is not None and output_path.stat().st_size > 0:
+        format_info = probe.get("format", {})
+        finalized.update(
+            {
+                "status": "recorded",
+                "duration_secs": float(format_info.get("duration", 0.0)),
+                "file_size_bytes": int(format_info.get("size", output_path.stat().st_size)),
+                "file_size_mb": round(output_path.stat().st_size / (1024 * 1024), 2),
+                "streams": probe.get("streams", []),
+            }
+        )
+        finalized.pop("error", None)
+    else:
+        finalized["status"] = "failed"
+        finalized["error"] = error or "FFmpeg did not produce a valid media file."
+
+    _write_json_atomic(meta_path, finalized)
+    if finalized["status"] == "recorded":
+        hooks.emit(
+            "recording_saved",
+            output_path=str(output_path),
+            meta_path=str(meta_path),
+            duration_secs=finalized["duration_secs"],
+        )
+    return finalized
 
 
 def _default_output_dir() -> Path:
@@ -190,11 +404,75 @@ def is_recording() -> int | None:
         return None
     try:
         pid = int(PID_FILE.read_text().strip())
-        os.kill(pid, 0)
-        return pid
-    except ValueError, ProcessLookupError, PermissionError:
-        PID_FILE.unlink(missing_ok=True)
+    except ValueError, OSError:
+        _clear_active_state()
         return None
+
+    state = _read_active_state()
+    output_path = str(state.get("output")) if state and state.get("output") else None
+    if _process_matches(pid, output_path):
+        return pid
+
+    if state and state.get("pid") == pid and state.get("output"):
+        try:
+            _finalize_recording(_metadata_from_state(state), error=_log_error(state))
+        finally:
+            _clear_active_state()
+    else:
+        _clear_active_state()
+    return None
+
+
+def stop_recording(timeout: float = 5.0) -> dict[str, Any]:
+    """Gracefully stop and finalize the active background recording."""
+    with _control_lock():
+        state = _read_active_state()
+        if state is None:
+            raise RuntimeError("No recording is currently in progress.")
+
+        try:
+            pid = int(state["pid"])
+        except (KeyError, TypeError, ValueError) as error:
+            _clear_active_state()
+            raise RuntimeError("Active recording state has no valid PID.") from error
+
+        meta = _metadata_from_state(state)
+        meta_path = Path(meta["output"]).with_suffix(".json")
+        if not _process_matches(pid, str(state["output"])):
+            try:
+                return _finalize_recording(meta, error=_log_error(state))
+            finally:
+                _clear_active_state()
+
+        os.kill(pid, signal.SIGINT)
+        deadline = time.monotonic() + timeout
+        while _pid_exists(pid) and time.monotonic() < deadline:
+            time.sleep(0.1)
+
+        if _pid_exists(pid):
+            os.kill(pid, signal.SIGTERM)
+            fallback_deadline = time.monotonic() + 1.0
+            while _pid_exists(pid) and time.monotonic() < fallback_deadline:
+                time.sleep(0.1)
+
+        error = None
+        if _pid_exists(pid):
+            error = f"FFmpeg process {pid} did not exit after SIGINT and SIGTERM."
+            failed = dict(meta)
+            failed.update(
+                {
+                    "status": "failed",
+                    "stopped_at": datetime.now().isoformat(),
+                    "error": error,
+                }
+            )
+            _write_json_atomic(meta_path, failed)
+            raise RuntimeError(error)
+
+        try:
+            return _finalize_recording(meta)
+        finally:
+            _clear_active_state()
 
 
 def resolve_sink(device: int | None) -> tuple[int, str]:
@@ -253,23 +531,24 @@ def record_foreground(
 ) -> None:
     """Run FFmpeg in the foreground, blocking until stopped."""
     cmd = build_ffmpeg_cmd(output_path, monitor_name, audio_format, mic_source=mic_source)
+    meta = _recording_metadata(
+        output_path, monitor_name, sink_id, audio_format, mic_source, mic_id
+    )
+    meta_path = output_path.with_suffix(".json")
+    log_path = output_path.with_suffix(f"{output_path.suffix}.ffmpeg.log")
 
-    meta = {
-        "source": f"{monitor_name}.monitor",
-        "sink_id": sink_id,
-        "format": audio_format,
-        "started_at": datetime.now().isoformat(),
-        "output": str(output_path),
-        "dual_channel": mic_source is not None,
-    }
-    if mic_source:
-        meta["mic_source"] = mic_source
-        meta["mic_id"] = mic_id
-
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # noqa: S603
-
-    PID_FILE.parent.mkdir(parents=True, exist_ok=True)
-    PID_FILE.write_text(str(proc.pid))
+    with _control_lock():
+        if is_recording():
+            raise RuntimeError("A recording is already in progress.")
+        _write_json_atomic(meta_path, meta)
+        try:
+            proc = subprocess.Popen(  # noqa: S603
+                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
+            )
+        except OSError as error:
+            _mark_start_failed(meta, error)
+            raise RuntimeError(f"Could not start FFmpeg: {error}") from error
+        _write_active_state(proc.pid, meta, log_path)
 
     hooks.emit(
         "recording_started",
@@ -285,26 +564,12 @@ def record_foreground(
     signal.signal(signal.SIGTERM, handle_stop)
 
     _, stderr = proc.communicate()
+    if stderr:
+        log_path.write_bytes(stderr)
+    _clear_active_state()
+    finalized = _finalize_recording(meta, error=stderr.decode(errors="replace")[-500:] or None)
 
-    PID_FILE.unlink(missing_ok=True)
-    meta["stopped_at"] = datetime.now().isoformat()
-
-    if output_path.exists():
-        meta["file_size_mb"] = round(output_path.stat().st_size / (1024 * 1024), 2)
-        meta_path = output_path.with_suffix(".json")
-        meta_path.write_text(json.dumps(meta, indent=2))
-
-        started = datetime.fromisoformat(meta["started_at"])
-        stopped = datetime.fromisoformat(meta["stopped_at"])
-        duration_secs = (stopped - started).total_seconds()
-
-        hooks.emit(
-            "recording_saved",
-            output_path=str(output_path),
-            meta_path=str(meta_path),
-            duration_secs=duration_secs,
-        )
-
+    if finalized["status"] == "recorded":
         console.print(f"\n[bold green]Recording saved:[/bold green] {output_path}")
         console.print(f"[dim]Metadata: {meta_path}[/dim]")
     else:
@@ -323,31 +588,28 @@ def record_background(
 ) -> int:
     """Launch FFmpeg as a detached background process. Returns PID."""
     cmd = build_ffmpeg_cmd(output_path, monitor_name, audio_format, mic_source=mic_source)
-
-    meta = {
-        "source": f"{monitor_name}.monitor",
-        "sink_id": sink_id,
-        "format": audio_format,
-        "started_at": datetime.now().isoformat(),
-        "output": str(output_path),
-        "dual_channel": mic_source is not None,
-    }
-    if mic_source:
-        meta["mic_source"] = mic_source
-        meta["mic_id"] = mic_id
-
-    meta_path = output_path.with_suffix(".json")
-    meta_path.write_text(json.dumps(meta, indent=2))
-
-    proc = subprocess.Popen(  # noqa: S603
-        cmd,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
+    meta = _recording_metadata(
+        output_path, monitor_name, sink_id, audio_format, mic_source, mic_id
     )
+    meta_path = output_path.with_suffix(".json")
+    log_path = output_path.with_suffix(f"{output_path.suffix}.ffmpeg.log")
 
-    PID_FILE.parent.mkdir(parents=True, exist_ok=True)
-    PID_FILE.write_text(str(proc.pid))
+    with _control_lock():
+        if is_recording():
+            raise RuntimeError("A recording is already in progress.")
+        _write_json_atomic(meta_path, meta)
+        try:
+            with log_path.open("ab") as log:
+                proc = subprocess.Popen(  # noqa: S603
+                    cmd,
+                    stdout=subprocess.DEVNULL,
+                    stderr=log,
+                    start_new_session=True,
+                )
+        except OSError as error:
+            _mark_start_failed(meta, error)
+            raise RuntimeError(f"Could not start FFmpeg: {error}") from error
+        _write_active_state(proc.pid, meta, log_path)
 
     hooks.emit(
         "recording_started",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,6 +63,23 @@ def test_status_not_recording():
     assert "Not recording" in result.output
 
 
+def test_toggle_stop_uses_shared_finalizer(tmp_path):
+    output = tmp_path / "meeting.flac"
+    finalized = {"status": "recorded", "output": str(output), "duration_secs": 12.5}
+
+    with (
+        patch("murmur.cli.is_recording", return_value=4321),
+        patch("murmur.cli.stop_recording", return_value=finalized) as stop,
+        patch("murmur.cli.notify"),
+    ):
+        result = runner.invoke(cli, ["toggle"])
+
+    assert result.exit_code == 0
+    assert "Stopped recording" in result.output
+    assert str(output) in result.output
+    stop.assert_called_once_with()
+
+
 def test_list_no_directory(tmp_path):
     with patch(
         "murmur.recorder._default_output_dir",

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,7 +1,11 @@
 """Tests for recorder module — PipeWire parsing, FFmpeg cmd building, helpers."""
 
+import json
+import signal
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
+
+import pytest
 
 from murmur import recorder
 
@@ -220,3 +224,151 @@ def test_is_recording_stale_pid(tmp_path):
     with patch.object(recorder, "PID_FILE", pid_file):
         assert recorder.is_recording() is None
     assert not pid_file.exists()
+
+
+def test_is_recording_rejects_reused_pid(tmp_path):
+    pid_file = tmp_path / "murmur.pid"
+    pid_file.write_text("1234")
+    pid_file.with_name("recording.json").write_text(
+        json.dumps({"pid": 1234, "output": "/tmp/meeting.flac"})
+    )
+
+    with (
+        patch.object(recorder, "PID_FILE", pid_file),
+        patch.object(recorder, "_process_matches", return_value=False),
+        patch.object(recorder, "_finalize_recording") as finalize,
+    ):
+        assert recorder.is_recording() is None
+
+    finalize.assert_called_once()
+    assert not pid_file.exists()
+    assert not pid_file.with_name("recording.json").exists()
+
+
+def test_finalize_recording_uses_ffprobe_metadata(tmp_path):
+    output = tmp_path / "meeting.flac"
+    output.write_bytes(b"audio")
+    meta = {
+        "status": "recording",
+        "started_at": "2026-07-20T10:00:00",
+        "output": str(output),
+    }
+    probe = {
+        "format": {"duration": "12.5", "size": "5"},
+        "streams": [{"index": 0, "codec_name": "flac", "codec_type": "audio"}],
+    }
+
+    with (
+        patch.object(recorder, "_probe_media", return_value=probe),
+        patch.object(recorder.hooks, "emit") as emit,
+    ):
+        finalized = recorder._finalize_recording(meta)
+
+    assert finalized["status"] == "recorded"
+    assert finalized["duration_secs"] == 12.5
+    assert finalized["file_size_bytes"] == 5
+    assert finalized["streams"] == probe["streams"]
+    assert json.loads(output.with_suffix(".json").read_text())["status"] == "recorded"
+    emit.assert_called_once_with(
+        "recording_saved",
+        output_path=str(output),
+        meta_path=str(output.with_suffix(".json")),
+        duration_secs=12.5,
+    )
+
+
+def test_record_background_persists_active_state(tmp_path):
+    pid_file = tmp_path / "cache" / "murmur.pid"
+    output = tmp_path / "meeting.flac"
+    process = MagicMock(pid=4321)
+
+    with (
+        patch.object(recorder, "PID_FILE", pid_file),
+        patch.object(recorder, "is_recording", return_value=None),
+        patch.object(recorder.subprocess, "Popen", return_value=process),
+        patch.object(recorder.hooks, "emit") as emit,
+    ):
+        pid = recorder.record_background(output, "sink", 91, "flac")
+
+    assert pid == 4321
+    assert pid_file.read_text().strip() == "4321"
+    state = json.loads(pid_file.with_name("recording.json").read_text())
+    assert state["pid"] == 4321
+    assert state["output"] == str(output)
+    assert json.loads(output.with_suffix(".json").read_text())["status"] == "recording"
+    emit.assert_called_once_with(
+        "recording_started",
+        pid=4321,
+        output_path=str(output),
+        source="sink.monitor",
+    )
+
+
+def test_stop_recording_gracefully_finalizes_and_clears_state(tmp_path):
+    pid_file = tmp_path / "cache" / "murmur.pid"
+    pid_file.parent.mkdir()
+    pid_file.write_text("4321")
+    output = tmp_path / "meeting.flac"
+    meta_path = output.with_suffix(".json")
+    meta = {"status": "recording", "started_at": "2026-07-20T10:00:00", "output": str(output)}
+    meta_path.write_text(json.dumps(meta))
+    pid_file.with_name("recording.json").write_text(
+        json.dumps({"pid": 4321, "output": str(output), "meta_path": str(meta_path)})
+    )
+    finalized = {**meta, "status": "recorded", "duration_secs": 12.5}
+
+    with (
+        patch.object(recorder, "PID_FILE", pid_file),
+        patch.object(recorder, "_process_matches", return_value=True),
+        patch.object(recorder, "_pid_exists", return_value=False),
+        patch.object(recorder, "_finalize_recording", return_value=finalized) as finalize,
+        patch.object(recorder.os, "kill") as kill,
+    ):
+        result = recorder.stop_recording()
+
+    assert result == finalized
+    kill.assert_called_once_with(4321, signal.SIGINT)
+    finalize.assert_called_once_with(meta)
+    assert not pid_file.exists()
+    assert not pid_file.with_name("recording.json").exists()
+
+
+def test_stop_recording_uses_sigterm_after_timeout(tmp_path):
+    pid_file = tmp_path / "cache" / "murmur.pid"
+    pid_file.parent.mkdir()
+    pid_file.write_text("4321")
+    output = tmp_path / "meeting.flac"
+    meta_path = output.with_suffix(".json")
+    meta = {"status": "recording", "started_at": "2026-07-20T10:00:00", "output": str(output)}
+    meta_path.write_text(json.dumps(meta))
+    pid_file.with_name("recording.json").write_text(
+        json.dumps({"pid": 4321, "output": str(output), "meta_path": str(meta_path)})
+    )
+
+    with (
+        patch.object(recorder, "PID_FILE", pid_file),
+        patch.object(recorder, "_process_matches", return_value=True),
+        patch.object(recorder, "_pid_exists", side_effect=[True, True, False, False]),
+        patch.object(recorder, "_finalize_recording", return_value={**meta, "status": "recorded"}),
+        patch.object(recorder.os, "kill") as kill,
+    ):
+        recorder.stop_recording(timeout=0)
+
+    assert kill.call_args_list == [call(4321, signal.SIGINT), call(4321, signal.SIGTERM)]
+
+
+def test_record_background_marks_spawn_failure(tmp_path):
+    pid_file = tmp_path / "cache" / "murmur.pid"
+    output = tmp_path / "meeting.flac"
+
+    with (
+        patch.object(recorder, "PID_FILE", pid_file),
+        patch.object(recorder, "is_recording", return_value=None),
+        patch.object(recorder.subprocess, "Popen", side_effect=OSError("ffmpeg missing")),
+        pytest.raises(RuntimeError, match="Could not start FFmpeg"),
+    ):
+        recorder.record_background(output, "sink", 91, "flac")
+
+    metadata = json.loads(output.with_suffix(".json").read_text())
+    assert metadata["status"] == "failed"
+    assert "ffmpeg missing" in metadata["error"]


### PR DESCRIPTION
## What

- persist active recording state alongside the PID
- verify process identity before sending signals
- stop FFmpeg with SIGINT and a bounded SIGTERM fallback
- finalize background recordings with ffprobe-derived duration, size, and streams
- emit `recording_saved` consistently from CLI, watch, and TUI flows
- preserve FFmpeg logs and mark failed starts/finalization in metadata

## Why

Background stop paths previously sent SIGTERM directly and skipped metadata finalization and the `recording_saved` hook. A stale or reused PID could also target an unrelated process.

## Checks

- `uv --no-config run --locked --with pytest --with pytest-cov pytest` (59 passed)
- `uvx --no-config ruff format --check .`
- `uvx --no-config ruff check .`

Closes #19