### PR TITLE
docs add lightweight contribution workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Report reproducible behavior that is not working as expected
+title: "bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for helping improve Murmur. Please remove secrets from logs.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the problem and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce it?
+      placeholder: |
+        1. Run ...
+        2. Configure ...
+        3. See ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Murmur version or commit
+      placeholder: 0.1.0 or commit SHA
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Linux distribution, PipeWire, FFmpeg, Python, and install method.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/rororowyourboat/murmur/security/advisories/new
+    about: Report vulnerabilities privately instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Propose a focused improvement to Murmur
+title: "feature: "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow or limitation should this improve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the smallest useful version and how it should work.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## What changed
+
+<!-- Briefly describe the change. -->
+
+## Why
+
+<!-- Link the issue: Closes #123 -->
+
+## Verification
+
+- [ ] `make check`
+- [ ] Behavior-changing code has tests
+- [ ] User-facing changes update documentation
+
+## Notes
+
+<!-- Risks, screenshots, follow-ups, or “None”. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "latest"
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Code of Conduct
+
+Murmur should be a welcoming, harassment-free project for everyone.
+
+Be respectful, assume good intent, give actionable feedback, and focus on the
+work rather than the person. Harassment, discrimination, threats, sexualized
+attention, deliberate intimidation, and publishing another person's private
+information are not acceptable.
+
+Project maintainers may edit or remove contributions and may temporarily or
+permanently restrict participation when behavior is inappropriate. Enforcement
+decisions will consider context, impact, and repeated behavior.
+
+Report conduct concerns privately to the maintainer through the contact options
+on [@rororowyourboat's GitHub profile](https://github.com/rororowyourboat).
+Reports will be handled as confidentially as practical. Do not use public issues
+to report sensitive conduct concerns.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to Murmur
+
+Thanks for helping improve Murmur. The workflow is intentionally small:
+
+1. Search the issues, then open one for a bug or meaningful feature.
+2. Create a short-lived branch from `main` (for example, `fix/recording-stop`).
+3. Keep the change focused and add or update tests when behavior changes.
+4. Run `make check`.
+5. Open a draft pull request and link its issue with `Closes #123`.
+6. Mark it ready once CI passes and all review conversations are resolved.
+
+Small documentation and typo fixes may skip the issue. Please do not include
+unrelated cleanup in the same pull request.
+
+## Development setup
+
+Murmur uses Python 3.14+ and [uv](https://docs.astral.sh/uv/).
+
+```bash
+make install
+make check
+```
+
+Use clear, imperative commit messages. Pull requests are squash-merged, so a
+perfectly curated commit history is not required.
+
+By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+For vulnerabilities, follow [SECURITY.md](SECURITY.md) instead of opening a
+public issue.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ make test          # pytest
 make fix           # ruff check --fix
 ```
 
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the small
+issue → branch → draft PR → CI workflow. Please report vulnerabilities using
+the private process in [SECURITY.md](SECURITY.md).
+
 ## Roadmap
 
 - [ ] Automatic transcription (Whisper local / Deepgram API)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+Security fixes are provided on the `main` branch. Older revisions are not
+maintained separately.
+
+Please report vulnerabilities through GitHub's **Report a vulnerability**
+button on the repository's Security tab. Include reproduction steps, affected
+versions or commits, impact, and any suggested mitigation.
+
+Do not open a public issue for an undisclosed vulnerability. You should receive
+an initial acknowledgement within seven days. Once a fix is available, the
+maintainer will coordinate disclosure and credit with the reporter.


### PR DESCRIPTION
## What

- document a short issue → branch → draft PR → CI workflow
- add concise pull request, bug, and feature templates
- add project conduct and private security-reporting policies
- link the contribution and security paths from the README
- move CI actions from deprecated Node 20 versions to current Node 24 releases

## Repository settings applied

- require PRs into `main` with zero required approvals while solo
- require the existing `check` CI job and an up-to-date branch
- require resolved review conversations
- enforce rules for admins; block force pushes and branch deletion
- enable squash-only merging and automatic branch deletion
- enable private vulnerability reporting

## Verification

- `uv --no-config run --locked --with pytest --with pytest-cov pytest` (52 passed)
- `uvx --no-config ruff format --check .`
- `uvx --no-config ruff check .`
- issue form and workflow YAML parsed successfully
- GitHub Actions `check` passed with the updated action versions

License selection remains a separate maintainer decision.

Closes #25