### PR TITLE
feat add multitrack MKA capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ murmur devices
 murmur start
 murmur start --tag standup --format mp3
 
+# Capture a default playback mix plus separate mic and call-output tracks
+murmur start --mic
+
 # Toggle recording on/off (for keyboard shortcuts)
 murmur toggle
 
@@ -105,6 +108,11 @@ Saved to `~/Recordings/meetings/` with naming convention:
 meeting_standup_2026-03-18_14-30-00.flac
 meeting_standup_2026-03-18_14-30-00.json   # metadata
 ```
+
+Recordings made with `--mic` use Matroska (`.mka`) and contain three named Opus
+streams: **Mixed call** (the default playback stream), **Microphone**, and
+**Call output**. The source streams remain independently selectable in players
+such as VLC and in FFmpeg.
 
 ## Configuration
 

--- a/src/murmur/cli.py
+++ b/src/murmur/cli.py
@@ -138,7 +138,7 @@ def devices():
     "--mic",
     is_flag=True,
     default=False,
-    help="Also capture microphone input (dual-channel).",
+    help="Capture a three-stream MKA with mix, microphone, and call output.",
 )
 @click.option(
     "--mic-device",
@@ -156,19 +156,21 @@ def start(
 ):
     """Start recording system audio."""
     sink_id, monitor_name = resolve_sink(device)
-    output_path = make_output_path(output, audio_format, tag)
 
     mic_source = None
     mic_id = None
     if mic:
         mic_id, mic_source = resolve_source(mic_device)
+    output_path = make_output_path(output, audio_format, tag, multitrack=mic_source is not None)
 
     console.print("[bold green]Recording started[/bold green]")
     console.print(f"  System: [cyan]{monitor_name}.monitor[/cyan]")
     if mic_source:
         console.print(f"  Mic:    [cyan]{mic_source}[/cyan]")
     console.print(f"  Output: [cyan]{output_path}[/cyan]")
-    console.print(f"  Format: [cyan]{audio_format}[/cyan]")
+    console.print(
+        f"  Format: [cyan]{'mka (3 Opus streams)' if mic_source else audio_format}[/cyan]"
+    )
     console.print("\n[yellow]Press Ctrl+C to stop recording.[/yellow]\n")
 
     record_foreground(
@@ -252,7 +254,7 @@ def list_recordings():
     "--mic",
     is_flag=True,
     default=False,
-    help="Also capture microphone input (dual-channel).",
+    help="Capture a three-stream MKA with mix, microphone, and call output.",
 )
 @click.option(
     "--mic-device",
@@ -276,12 +278,12 @@ def toggle(audio_format: str, tag: str | None, mic: bool, mic_device: int | None
         return
 
     sink_id, monitor_name = resolve_sink(None)
-    output_path = make_output_path(None, audio_format, tag)
 
     mic_source = None
     mic_id = None
     if mic:
         mic_id, mic_source = resolve_source(mic_device)
+    output_path = make_output_path(None, audio_format, tag, multitrack=mic_source is not None)
 
     pid = record_background(
         output_path,

--- a/src/murmur/plugins/tui.py
+++ b/src/murmur/plugins/tui.py
@@ -21,7 +21,7 @@ from murmur.recorder import (
     stop_recording,
 )
 
-AUDIO_SUFFIXES = {".flac", ".mp3", ".wav", ".ogg", ".m4a", ".opus"}
+AUDIO_SUFFIXES = {".flac", ".mp3", ".wav", ".ogg", ".m4a", ".opus", ".mka"}
 
 
 # ---------------------------------------------------------------------------

--- a/src/murmur/plugins/watch.py
+++ b/src/murmur/plugins/watch.py
@@ -127,7 +127,7 @@ def register(cli: click.Group) -> None:
         "--mic",
         is_flag=True,
         default=False,
-        help="Include microphone in auto-recordings (dual-channel).",
+        help="Capture mix, microphone, and call output as a three-stream MKA.",
     )
     def watch(interval: int | None, auto_record: bool, audio_format: str, mic: bool):
         """Watch for meeting apps using the microphone.
@@ -175,7 +175,6 @@ def register(cli: click.Group) -> None:
                     if auto_record and not is_recording():
                         sink_id, monitor_name = resolve_sink(None)
                         tag = app_name.lower().replace(" ", "-")
-                        output_path = make_output_path(None, audio_format, tag)
 
                         mic_source = None
                         mic_id = None
@@ -183,6 +182,12 @@ def register(cli: click.Group) -> None:
                             from murmur.recorder import resolve_source
 
                             mic_id, mic_source = resolve_source(None)
+                        output_path = make_output_path(
+                            None,
+                            audio_format,
+                            tag,
+                            multitrack=mic_source is not None,
+                        )
 
                         record_background(
                             output_path,

--- a/src/murmur/recorder.py
+++ b/src/murmur/recorder.py
@@ -24,6 +24,31 @@ console = Console()
 
 PID_FILE = Path.home() / ".cache" / "murmur" / "murmur.pid"
 
+MULTITRACK_FORMAT = "mka"
+MULTITRACK_STREAMS = (
+    {
+        "index": 0,
+        "title": "Mixed call",
+        "codec": "opus",
+        "source_role": "mixed",
+        "default": True,
+    },
+    {
+        "index": 1,
+        "title": "Microphone",
+        "codec": "opus",
+        "source_role": "microphone",
+        "default": False,
+    },
+    {
+        "index": 2,
+        "title": "Call output",
+        "codec": "opus",
+        "source_role": "call_output",
+        "default": False,
+    },
+)
+
 
 def _state_file() -> Path:
     return PID_FILE.with_name("recording.json")
@@ -104,18 +129,31 @@ def _recording_metadata(
     mic_source: str | None,
     mic_id: int | None,
 ) -> dict[str, Any]:
+    multitrack = mic_source is not None
+    effective_format = MULTITRACK_FORMAT if multitrack else audio_format
     meta: dict[str, Any] = {
         "status": "recording",
         "source": f"{monitor_name}.monitor",
         "sink_id": sink_id,
-        "format": audio_format,
+        "format": effective_format,
         "started_at": datetime.now().isoformat(),
         "output": str(output_path),
-        "dual_channel": mic_source is not None,
+        "dual_channel": multitrack,
+        "capture_mode": "multitrack" if multitrack else "system_output",
     }
     if mic_source:
+        meta["requested_format"] = audio_format
         meta["mic_source"] = mic_source
         meta["mic_id"] = mic_id
+        source_names = {
+            "mixed": [f"{monitor_name}.monitor", mic_source],
+            "microphone": [mic_source],
+            "call_output": [f"{monitor_name}.monitor"],
+        }
+        meta["stream_layout"] = [
+            {**stream, "source_names": source_names[stream["source_role"]]}
+            for stream in MULTITRACK_STREAMS
+        ]
     return meta
 
 
@@ -183,7 +221,8 @@ def _probe_media(output_path: Path) -> dict[str, Any] | None:
             "-v",
             "error",
             "-show_entries",
-            "format=duration,size:stream=index,codec_name,codec_type,channels",
+            "format=duration,size:stream=index,codec_name,codec_type,channels:"
+            "stream_tags=title:stream_disposition=default",
             "-of",
             "json",
             str(output_path),
@@ -209,13 +248,33 @@ def _finalize_recording(meta: dict[str, Any], error: str | None = None) -> dict[
     probe = _probe_media(output_path) if output_path.is_file() else None
     if probe is not None and output_path.stat().st_size > 0:
         format_info = probe.get("format", {})
+        streams = probe.get("streams", [])
+        planned_streams = {stream["index"]: stream for stream in meta.get("stream_layout", [])}
+        enriched_streams = []
+        for stream in streams:
+            planned = planned_streams.get(stream.get("index"), {})
+            probed_title = stream.get("tags", {}).get("title")
+            if not planned and not probed_title:
+                enriched_streams.append(stream)
+                continue
+            enriched_streams.append(
+                {
+                    **stream,
+                    "title": probed_title or planned.get("title"),
+                    "source_role": planned.get("source_role"),
+                    "source_names": planned.get("source_names", []),
+                    "default": bool(
+                        stream.get("disposition", {}).get("default", planned.get("default", False))
+                    ),
+                }
+            )
         finalized.update(
             {
                 "status": "recorded",
                 "duration_secs": float(format_info.get("duration", 0.0)),
                 "file_size_bytes": int(format_info.get("size", output_path.stat().st_size)),
                 "file_size_mb": round(output_path.stat().st_size / (1024 * 1024), 2),
-                "streams": probe.get("streams", []),
+                "streams": enriched_streams,
             }
         )
         finalized.pop("error", None)
@@ -361,31 +420,57 @@ def build_ffmpeg_cmd(
 ) -> list[str]:
     """Build FFmpeg command for recording.
 
-    If mic_source is provided, mixes system audio (left channel) and mic
-    (right channel) into a stereo file. This keeps compatibility with all
-    audio formats and lets diarization split channels later.
+    If mic_source is provided, produce a Matroska file with a default listening
+    mix plus independently selectable microphone and call-output streams.
     """
     system_source = f"{monitor_source}.monitor"
 
-    cmd = ["ffmpeg", "-y"]
+    cmd = ["ffmpeg", "-y", "-thread_queue_size", "1024"]
 
     # Input 0: system audio
     cmd += ["-f", "pulse", "-i", system_source]
 
     if mic_source:
-        # Input 1: microphone
-        cmd += ["-f", "pulse", "-i", mic_source]
-        # Mix into stereo: system=left, mic=right
+        if output_path.suffix.lower() != ".mka":
+            raise ValueError("Microphone capture requires an .mka output path.")
+        cmd += ["-thread_queue_size", "1024", "-f", "pulse", "-i", mic_source]
         cmd += [
             "-filter_complex",
-            "[0:a][1:a]amerge=inputs=2[out]",
+            "[0:a]aresample=async=1000:first_pts=0,asplit=2[call_mix][call_track];"
+            "[1:a]aresample=async=1000:first_pts=0,asplit=2[mic_mix][mic_track];"
+            "[call_mix][mic_mix]amix=inputs=2:duration=longest:dropout_transition=0:"
+            "normalize=0,alimiter=limit=0.95:level=false[mix]",
             "-map",
-            "[out]",
-            "-ac",
-            "2",
+            "[mix]",
+            "-map",
+            "[mic_track]",
+            "-map",
+            "[call_track]",
+            "-c:a",
+            "libopus",
+            "-b:a:0",
+            "128k",
+            "-b:a:1",
+            "96k",
+            "-b:a:2",
+            "96k",
+            "-metadata:s:a:0",
+            "title=Mixed call",
+            "-metadata:s:a:1",
+            "title=Microphone",
+            "-metadata:s:a:2",
+            "title=Call output",
+            "-disposition:a:0",
+            "default",
+            "-disposition:a:1",
+            "0",
+            "-disposition:a:2",
+            "0",
+            "-f",
+            "matroska",
         ]
-
-    cmd += _codec_args(audio_format)
+    else:
+        cmd += _codec_args(audio_format)
     cmd.append(str(output_path))
     return cmd
 
@@ -509,16 +594,19 @@ def make_output_path(
     output: str | None,
     audio_format: str,
     tag: str | None,
+    multitrack: bool = False,
 ) -> Path:
     """Build the output file path from options or generate one."""
     if output:
-        return Path(output)
+        path = Path(output)
+        return path.with_suffix(".mka") if multitrack else path
 
     recordings_dir = _default_output_dir()
     recordings_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     tag_part = f"_{tag}" if tag else ""
-    return recordings_dir / f"meeting{tag_part}_{timestamp}.{audio_format}"
+    suffix = MULTITRACK_FORMAT if multitrack else audio_format
+    return recordings_dir / f"meeting{tag_part}_{timestamp}.{suffix}"
 
 
 def record_foreground(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,3 +152,26 @@ def test_start_help_shows_mic_option():
     assert result.exit_code == 0
     assert "--mic" in result.output
     assert "--mic-device" in result.output
+
+
+def test_start_with_mic_uses_multitrack_mka(tmp_path):
+    requested = tmp_path / "call.flac"
+
+    with (
+        patch("murmur.cli.resolve_sink", return_value=(91, "alsa_output.test")),
+        patch("murmur.cli.resolve_source", return_value=(58, "alsa_input.mic")),
+        patch("murmur.cli.record_foreground") as record,
+    ):
+        result = runner.invoke(cli, ["start", "--mic", "--output", str(requested)])
+
+    assert result.exit_code == 0
+    assert "call.mka" in result.output
+    assert "3 Opus streams" in result.output
+    record.assert_called_once_with(
+        tmp_path / "call.mka",
+        "alsa_output.test",
+        91,
+        "flac",
+        mic_source="alsa_input.mic",
+        mic_id=58,
+    )

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -134,6 +134,8 @@ def test_build_ffmpeg_cmd_flac():
     assert cmd == [
         "ffmpeg",
         "-y",
+        "-thread_queue_size",
+        "1024",
         "-f",
         "pulse",
         "-i",
@@ -161,34 +163,73 @@ def test_build_ffmpeg_cmd_ogg():
     assert "libvorbis" in cmd
 
 
-def test_build_ffmpeg_cmd_dual_channel():
+def test_build_ffmpeg_cmd_multitrack_mka():
     cmd = recorder.build_ffmpeg_cmd(
-        Path("/tmp/out.flac"),
+        Path("/tmp/out.mka"),
         "alsa_output.test",
         "flac",
         mic_source="alsa_input.mic",
     )
-    # Should have two -i inputs
-    i_indices = [i for i, v in enumerate(cmd) if v == "-i"]
-    assert len(i_indices) == 2
-    assert cmd[i_indices[0] + 1] == "alsa_output.test.monitor"
-    assert cmd[i_indices[1] + 1] == "alsa_input.mic"
-    # Should use amerge filter to mix into stereo
-    assert "-filter_complex" in cmd
-    assert any("amerge" in v for v in cmd)
-    assert "-map" in cmd
-    assert "[out]" in cmd
+    assert cmd == [
+        "ffmpeg",
+        "-y",
+        "-thread_queue_size",
+        "1024",
+        "-f",
+        "pulse",
+        "-i",
+        "alsa_output.test.monitor",
+        "-thread_queue_size",
+        "1024",
+        "-f",
+        "pulse",
+        "-i",
+        "alsa_input.mic",
+        "-filter_complex",
+        "[0:a]aresample=async=1000:first_pts=0,asplit=2[call_mix][call_track];"
+        "[1:a]aresample=async=1000:first_pts=0,asplit=2[mic_mix][mic_track];"
+        "[call_mix][mic_mix]amix=inputs=2:duration=longest:dropout_transition=0:"
+        "normalize=0,alimiter=limit=0.95:level=false[mix]",
+        "-map",
+        "[mix]",
+        "-map",
+        "[mic_track]",
+        "-map",
+        "[call_track]",
+        "-c:a",
+        "libopus",
+        "-b:a:0",
+        "128k",
+        "-b:a:1",
+        "96k",
+        "-b:a:2",
+        "96k",
+        "-metadata:s:a:0",
+        "title=Mixed call",
+        "-metadata:s:a:1",
+        "title=Microphone",
+        "-metadata:s:a:2",
+        "title=Call output",
+        "-disposition:a:0",
+        "default",
+        "-disposition:a:1",
+        "0",
+        "-disposition:a:2",
+        "0",
+        "-f",
+        "matroska",
+        "/tmp/out.mka",
+    ]
 
 
-def test_build_ffmpeg_cmd_dual_channel_codec():
-    cmd = recorder.build_ffmpeg_cmd(
-        Path("/tmp/out.flac"),
-        "alsa_output.test",
-        "flac",
-        mic_source="alsa_input.mic",
-    )
-    assert "-c:a" in cmd
-    assert "flac" in cmd
+def test_build_ffmpeg_cmd_multitrack_requires_mka():
+    with pytest.raises(ValueError, match=r"requires an \.mka"):
+        recorder.build_ffmpeg_cmd(
+            Path("/tmp/out.flac"),
+            "alsa_output.test",
+            "flac",
+            mic_source="alsa_input.mic",
+        )
 
 
 def test_make_output_path_explicit():
@@ -211,6 +252,56 @@ def test_make_output_path_with_tag(tmp_path):
 
     assert "_standup_" in path.name
     assert path.suffix == ".mp3"
+
+
+def test_make_output_path_multitrack_forces_mka(tmp_path):
+    with patch.object(recorder, "_default_output_dir", return_value=tmp_path):
+        generated = recorder.make_output_path(None, "flac", "standup", multitrack=True)
+        explicit = recorder.make_output_path("/tmp/custom.flac", "flac", None, multitrack=True)
+
+    assert generated.suffix == ".mka"
+    assert explicit == Path("/tmp/custom.mka")
+
+
+def test_multitrack_metadata_records_stream_contract():
+    meta = recorder._recording_metadata(
+        Path("/tmp/meeting.mka"),
+        "alsa_output.test",
+        91,
+        "flac",
+        "alsa_input.mic",
+        58,
+    )
+
+    assert meta["format"] == "mka"
+    assert meta["requested_format"] == "flac"
+    assert meta["capture_mode"] == "multitrack"
+    assert meta["stream_layout"] == [
+        {
+            "index": 0,
+            "title": "Mixed call",
+            "codec": "opus",
+            "source_role": "mixed",
+            "default": True,
+            "source_names": ["alsa_output.test.monitor", "alsa_input.mic"],
+        },
+        {
+            "index": 1,
+            "title": "Microphone",
+            "codec": "opus",
+            "source_role": "microphone",
+            "default": False,
+            "source_names": ["alsa_input.mic"],
+        },
+        {
+            "index": 2,
+            "title": "Call output",
+            "codec": "opus",
+            "source_role": "call_output",
+            "default": False,
+            "source_names": ["alsa_output.test.monitor"],
+        },
+    ]
 
 
 def test_is_recording_no_pid_file(tmp_path):
@@ -275,6 +366,51 @@ def test_finalize_recording_uses_ffprobe_metadata(tmp_path):
         meta_path=str(output.with_suffix(".json")),
         duration_secs=12.5,
     )
+
+
+def test_finalize_recording_enriches_multitrack_stream_metadata(tmp_path):
+    output = tmp_path / "meeting.mka"
+    output.write_bytes(b"audio")
+    meta = recorder._recording_metadata(
+        output,
+        "alsa_output.test",
+        91,
+        "flac",
+        "alsa_input.mic",
+        58,
+    )
+    probe = {
+        "format": {"duration": "12.5", "size": "5"},
+        "streams": [
+            {
+                "index": index,
+                "codec_name": "opus",
+                "codec_type": "audio",
+                "tags": {"title": title},
+                "disposition": {"default": int(index == 0)},
+            }
+            for index, title in enumerate(("Mixed call", "Microphone", "Call output"))
+        ],
+    }
+
+    with (
+        patch.object(recorder, "_probe_media", return_value=probe),
+        patch.object(recorder.hooks, "emit"),
+    ):
+        finalized = recorder._finalize_recording(meta)
+
+    assert [stream["title"] for stream in finalized["streams"]] == [
+        "Mixed call",
+        "Microphone",
+        "Call output",
+    ]
+    assert [stream["source_role"] for stream in finalized["streams"]] == [
+        "mixed",
+        "microphone",
+        "call_output",
+    ]
+    assert finalized["streams"][0]["default"] is True
+    assert finalized["streams"][1]["source_names"] == ["alsa_input.mic"]
 
 
 def test_record_background_persists_active_state(tmp_path):


### PR DESCRIPTION
## What

- make `--mic` recordings use a three-stream Matroska container
- provide a default **Mixed call** stream plus independent **Microphone** and **Call output** streams
- asynchronously resample both capture clocks and limit the listening mix
- persist stream indexes, names, codecs, roles, dispositions, and source device names
- recognize MKA recordings in the TUI and document playback behavior

## Why

The previous `amerge` plus `-ac 2` path could unexpectedly collapse inputs that were already stereo and did not preserve independently selectable sources.

## Verification

- full suite: 63 passed
- Ruff formatting and lint passed
- generated synthetic audio with mismatched source sample rates
- ffprobe confirmed exactly three named Opus streams and the mix as the sole default
- volume analysis confirmed the limited mix does not exceed 0 dBFS

Closes #20