### PR TITLE
feat add canonical artifacts and jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Optional TOML config at `~/.config/murmur/config.toml`:
 ```toml
 [recording]
 output_dir = "~/Recordings/meetings"
+artifacts_dir = "~/Recordings/artifacts"
 format = "flac"
 
 [watch]
@@ -141,6 +142,34 @@ ollama_url = "http://localhost:11434"
 [diarize]
 hf_token = "hf_..."  # hugging face token for pyannote
 ```
+
+## Artifacts and processing jobs
+
+Each recording gets a content-fingerprinted manifest and durable job state. By
+default, generated files live under `~/Recordings/artifacts/<recording-id>/`:
+
+```text
+manifest.json
+jobs.json
+raw-responses/
+speakers/
+transcript.txt
+transcript.srt
+summary.md
+```
+
+Writes are atomic. Completed outputs are checksum-validated before they are
+reused, so interrupted commands can be run again without repeating valid work.
+
+```bash
+murmur jobs status <recording>
+murmur jobs status <recording> --json
+murmur jobs retry <recording> [--job transcribe]
+```
+
+Job metadata records provider and model parameters but removes credentials and
+embedded audio data. Raw provider responses are kept separately from derived
+transcripts and summaries.
 
 ## Plugins
 

--- a/src/murmur/artifacts.py
+++ b/src/murmur/artifacts.py
@@ -1,0 +1,506 @@
+"""Canonical recording artifacts and durable processing job state."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from murmur.config import get_section
+
+SCHEMA_VERSION = 1
+SECRET_MARKERS = ("secret", "token", "api_key", "apikey", "authorization", "credential")
+
+
+class CorruptStateError(RuntimeError):
+    """Raised when a persisted manifest or jobs file is not valid JSON state."""
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Durably replace a JSON file without exposing a partial write."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp")
+    try:
+        with temporary.open("w") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp")
+    try:
+        with temporary.open("w") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _read_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text())
+    except FileNotFoundError:
+        return default
+    except (json.JSONDecodeError, OSError) as error:
+        raise CorruptStateError(f"Could not read {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise CorruptStateError(f"Expected a JSON object in {path}.")
+    return payload
+
+
+def _sanitize(value: Any, key: str = "") -> Any:
+    """Remove credentials and embedded audio from persisted parameters."""
+    lowered = key.lower()
+    if any(marker in lowered for marker in SECRET_MARKERS):
+        return None
+    if isinstance(value, str):
+        if value.lstrip().lower().startswith("data:audio/"):
+            return "<redacted-audio-data-url>"
+        sanitized = re.sub(r"\b(?:sk-|hf_)[A-Za-z0-9_-]{8,}\b", "<redacted-secret>", value)
+        sanitized = re.sub(r"(?i)\bBearer\s+\S+", "Bearer <redacted-secret>", sanitized)
+        return re.sub(r"op://[^\s]+", "<redacted-secret-reference>", sanitized)
+    if isinstance(value, dict):
+        return {
+            child_key: sanitized
+            for child_key, child_value in value.items()
+            if (sanitized := _sanitize(child_value, str(child_key))) is not None
+        }
+    if isinstance(value, (list, tuple)):
+        return [_sanitize(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return str(value)
+
+
+def fingerprint_file(path: Path) -> dict[str, Any]:
+    """Return a stable content fingerprint for a source or artifact file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    stat = path.stat()
+    return {
+        "algorithm": "sha256",
+        "sha256": digest.hexdigest(),
+        "size_bytes": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+
+
+def default_artifacts_root(source: Path | None = None) -> Path:
+    """Return the configured artifact root beside the recordings directory."""
+    config = get_section("recording")
+    configured = config.get("artifacts_dir")
+    if configured:
+        return Path(configured).expanduser()
+    recordings_dir = Path(config.get("output_dir", "~/Recordings/meetings")).expanduser()
+    if source is not None and source.resolve().parent != recordings_dir.resolve():
+        return source.resolve().parent / "artifacts"
+    return recordings_dir.parent / "artifacts"
+
+
+class ArtifactStore:
+    """Manage one recording's canonical manifest, artifacts, and jobs."""
+
+    def __init__(self, recording: str | Path, root: str | Path | None = None):
+        self.recording = Path(recording).expanduser().resolve()
+        self.recording_id = self.recording.stem
+        artifacts_root = (
+            Path(root).expanduser() if root is not None else default_artifacts_root(self.recording)
+        )
+        artifacts_root = artifacts_root.resolve()
+        self.directory = artifacts_root / self.recording_id
+        existing_manifest = self.directory / "manifest.json"
+        if existing_manifest.exists():
+            existing = _read_json(existing_manifest, {})
+            if existing.get("recording") not in (None, str(self.recording)):
+                path_hash = hashlib.sha256(str(self.recording).encode()).hexdigest()[:8]
+                self.recording_id = f"{self.recording.stem}-{path_hash}"
+                self.directory = artifacts_root / self.recording_id
+        self.manifest_path = self.directory / "manifest.json"
+        self.jobs_path = self.directory / "jobs.json"
+
+    def path(self, relative: str | Path) -> Path:
+        candidate = (self.directory / relative).resolve()
+        if not candidate.is_relative_to(self.directory.resolve()):
+            raise ValueError("Artifact path must remain inside the recording artifact directory.")
+        return candidate
+
+    @classmethod
+    def for_input(cls, path: str | Path) -> ArtifactStore:
+        """Resolve an audio file or canonical artifact back to its recording."""
+        candidate = Path(path).expanduser().resolve()
+        for parent in (candidate.parent, *candidate.parents):
+            manifest_path = parent / "manifest.json"
+            if manifest_path.is_file():
+                manifest = _read_json(manifest_path, {})
+                recording = manifest.get("recording")
+                if recording:
+                    return cls(recording, root=parent.parent)
+        return cls(candidate)
+
+    def write_text(self, relative: str | Path, content: str) -> Path:
+        output = self.path(relative)
+        _atomic_write_text(output, content)
+        return output
+
+    def write_json(self, relative: str | Path, payload: dict[str, Any]) -> Path:
+        output = self.path(relative)
+        _atomic_write_json(output, payload)
+        return output
+
+    def _source_fingerprint(self, previous: dict[str, Any] | None = None) -> dict[str, Any]:
+        if not self.recording.is_file():
+            raise FileNotFoundError(f"Recording not found: {self.recording}")
+        stat = self.recording.stat()
+        if (
+            previous
+            and previous.get("size_bytes") == stat.st_size
+            and previous.get("mtime_ns") == stat.st_mtime_ns
+            and previous.get("sha256")
+        ):
+            return previous
+        return fingerprint_file(self.recording)
+
+    def ensure_manifest(self, media_metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Create or refresh the canonical manifest for the recording."""
+        existing = _read_json(self.manifest_path, {})
+        now = _now()
+        if media_metadata is None:
+            sidecar = self.recording.with_suffix(".json")
+            media_metadata = _read_json(sidecar, {}) if sidecar.exists() else {}
+        media_fields = (
+            "format",
+            "duration_secs",
+            "file_size_bytes",
+            "streams",
+            "source",
+            "sink_id",
+            "mic_source",
+            "mic_id",
+            "capture_mode",
+        )
+        media = dict(existing.get("media", {}))
+        media.update(
+            {field: media_metadata[field] for field in media_fields if field in media_metadata}
+        )
+        manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "recording_id": self.recording_id,
+            "recording": str(self.recording),
+            "source_fingerprint": self._source_fingerprint(existing.get("source_fingerprint")),
+            "media": media,
+            "artifacts": existing.get("artifacts", {}),
+            "created_at": existing.get("created_at", now),
+            "updated_at": now,
+        }
+        _atomic_write_json(self.manifest_path, manifest)
+        if not self.jobs_path.exists():
+            _atomic_write_json(
+                self.jobs_path,
+                {"schema_version": SCHEMA_VERSION, "jobs": {}, "updated_at": now},
+            )
+        return manifest
+
+    def manifest(self) -> dict[str, Any]:
+        return _read_json(self.manifest_path, {})
+
+    def jobs(self) -> dict[str, Any]:
+        return _read_json(
+            self.jobs_path,
+            {"schema_version": SCHEMA_VERSION, "jobs": {}, "updated_at": _now()},
+        )
+
+    def register_artifact(
+        self,
+        name: str,
+        path: str | Path,
+        *,
+        kind: str,
+        provenance: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Add a completed artifact and its checksum to the manifest inventory."""
+        artifact_path = Path(path).resolve()
+        if not artifact_path.is_file():
+            raise FileNotFoundError(f"Artifact not found: {artifact_path}")
+        if not artifact_path.is_relative_to(self.directory.resolve()):
+            raise ValueError("Registered artifacts must live in the canonical artifact directory.")
+        manifest = self.ensure_manifest()
+        entry = {
+            "path": str(artifact_path.relative_to(self.directory)),
+            "kind": kind,
+            "fingerprint": fingerprint_file(artifact_path),
+            "provenance": _sanitize(provenance or {}),
+            "created_at": _now(),
+        }
+        manifest["artifacts"][name] = entry
+        manifest["updated_at"] = _now()
+        _atomic_write_json(self.manifest_path, manifest)
+        return entry
+
+    def artifact_valid(self, name: str) -> bool:
+        entry = self.manifest().get("artifacts", {}).get(name)
+        if not entry:
+            return False
+        path = self.path(entry["path"])
+        if not path.is_file():
+            return False
+        expected = entry.get("fingerprint", {}).get("sha256")
+        return bool(expected and fingerprint_file(path)["sha256"] == expected)
+
+    @staticmethod
+    def job_id(job_type: str, provider: str) -> str:
+        return f"{job_type}:{provider}"
+
+    def begin_job(
+        self,
+        job_type: str,
+        provider: str,
+        *,
+        model: str | None = None,
+        parameters: dict[str, Any] | None = None,
+        input_paths: list[str | Path] | None = None,
+        output_paths: list[str | Path] | None = None,
+        output_artifacts: list[str] | None = None,
+        retryable: bool = True,
+        resume: bool = True,
+    ) -> tuple[dict[str, Any], bool]:
+        """Persist a running job; return ``(job, should_run)``."""
+        manifest = self.ensure_manifest()
+        payload = self.jobs()
+        identifier = self.job_id(job_type, provider)
+        previous = payload["jobs"].get(identifier, {})
+        outputs = output_artifacts or []
+        source_fingerprint = manifest["source_fingerprint"]
+        if (
+            resume
+            and previous.get("status") == "complete"
+            and outputs
+            and previous.get("source_fingerprint", {}).get("sha256")
+            == source_fingerprint["sha256"]
+            and all(self.artifact_valid(name) for name in outputs)
+        ):
+            return previous, False
+        now = _now()
+        job = {
+            "id": identifier,
+            "type": job_type,
+            "provider": provider,
+            "model": model,
+            "parameters": _sanitize(parameters or {}),
+            "status": "running",
+            "attempt_count": int(previous.get("attempt_count", 0)) + 1,
+            "created_at": previous.get("created_at", now),
+            "started_at": now,
+            "updated_at": now,
+            "completed_at": None,
+            "input_paths": [_sanitize(str(path)) for path in (input_paths or [self.recording])],
+            "output_paths": [_sanitize(str(path)) for path in (output_paths or [])],
+            "output_artifacts": outputs,
+            "source_fingerprint": source_fingerprint,
+            "last_error": None,
+            "retryable": retryable,
+            "units": previous.get("units", {}),
+        }
+        payload["jobs"][identifier] = job
+        payload["updated_at"] = now
+        _atomic_write_json(self.jobs_path, payload)
+        return job, True
+
+    def complete_job(self, job_type: str, provider: str) -> dict[str, Any]:
+        identifier = self.job_id(job_type, provider)
+        job = self.jobs().get("jobs", {}).get(identifier)
+        if job is None:
+            raise KeyError(f"Unknown job: {identifier}")
+        invalid = [
+            name for name in job.get("output_artifacts", []) if not self.artifact_valid(name)
+        ]
+        if invalid:
+            raise ValueError(
+                f"Cannot complete {identifier}; invalid artifacts: {', '.join(invalid)}"
+            )
+        return self._finish_job(job_type, provider, status="complete")
+
+    def fail_job(
+        self, job_type: str, provider: str, error: Exception | str, *, retryable: bool = True
+    ) -> dict[str, Any]:
+        return self._finish_job(
+            job_type,
+            provider,
+            status="failed",
+            error=_sanitize(str(error)),
+            retryable=retryable,
+        )
+
+    def _finish_job(
+        self,
+        job_type: str,
+        provider: str,
+        *,
+        status: str,
+        error: str | None = None,
+        retryable: bool | None = None,
+    ) -> dict[str, Any]:
+        payload = self.jobs()
+        identifier = self.job_id(job_type, provider)
+        if identifier not in payload["jobs"]:
+            raise KeyError(f"Unknown job: {identifier}")
+        now = _now()
+        job = payload["jobs"][identifier]
+        job.update(
+            {
+                "status": status,
+                "updated_at": now,
+                "completed_at": now if status == "complete" else None,
+                "last_error": error,
+            }
+        )
+        if retryable is not None:
+            job["retryable"] = retryable
+        payload["updated_at"] = now
+        _atomic_write_json(self.jobs_path, payload)
+        return job
+
+    def begin_unit(
+        self,
+        job_type: str,
+        provider: str,
+        unit_id: str,
+        *,
+        parameters: dict[str, Any] | None = None,
+        output_artifacts: list[str] | None = None,
+    ) -> tuple[dict[str, Any], bool]:
+        """Start one resumable job unit, skipping checksum-valid completed work."""
+        payload = self.jobs()
+        identifier = self.job_id(job_type, provider)
+        if identifier not in payload["jobs"]:
+            raise KeyError(f"Unknown job: {identifier}")
+        job = payload["jobs"][identifier]
+        units = job.setdefault("units", {})
+        previous = units.get(unit_id, {})
+        outputs = output_artifacts or []
+        if (
+            previous.get("status") == "complete"
+            and outputs
+            and all(self.artifact_valid(name) for name in outputs)
+        ):
+            return previous, False
+        now = _now()
+        unit = {
+            "id": unit_id,
+            "status": "running",
+            "attempt_count": int(previous.get("attempt_count", 0)) + 1,
+            "created_at": previous.get("created_at", now),
+            "started_at": now,
+            "updated_at": now,
+            "completed_at": None,
+            "parameters": _sanitize(parameters or {}),
+            "output_artifacts": outputs,
+            "last_error": None,
+            "retryable": True,
+        }
+        units[unit_id] = unit
+        job["updated_at"] = now
+        payload["updated_at"] = now
+        _atomic_write_json(self.jobs_path, payload)
+        return unit, True
+
+    def complete_unit(self, job_type: str, provider: str, unit_id: str) -> dict[str, Any]:
+        return self._finish_unit(job_type, provider, unit_id, status="complete")
+
+    def fail_unit(
+        self,
+        job_type: str,
+        provider: str,
+        unit_id: str,
+        error: Exception | str,
+        *,
+        retryable: bool = True,
+    ) -> dict[str, Any]:
+        return self._finish_unit(
+            job_type,
+            provider,
+            unit_id,
+            status="failed",
+            error=_sanitize(str(error)),
+            retryable=retryable,
+        )
+
+    def _finish_unit(
+        self,
+        job_type: str,
+        provider: str,
+        unit_id: str,
+        *,
+        status: str,
+        error: str | None = None,
+        retryable: bool | None = None,
+    ) -> dict[str, Any]:
+        payload = self.jobs()
+        identifier = self.job_id(job_type, provider)
+        try:
+            job = payload["jobs"][identifier]
+            unit = job["units"][unit_id]
+        except KeyError as missing:
+            raise KeyError(f"Unknown job unit: {identifier}/{unit_id}") from missing
+        if status == "complete":
+            invalid = [
+                name for name in unit.get("output_artifacts", []) if not self.artifact_valid(name)
+            ]
+            if invalid:
+                raise ValueError(
+                    f"Cannot complete {identifier}/{unit_id}; invalid artifacts: "
+                    f"{', '.join(invalid)}"
+                )
+        now = _now()
+        unit.update(
+            {
+                "status": status,
+                "updated_at": now,
+                "completed_at": now if status == "complete" else None,
+                "last_error": error,
+            }
+        )
+        if retryable is not None:
+            unit["retryable"] = retryable
+        job["updated_at"] = now
+        payload["updated_at"] = now
+        _atomic_write_json(self.jobs_path, payload)
+        return unit
+
+    def retry_failed(self, job_type: str | None = None) -> list[str]:
+        """Reset retryable failed jobs to pending and return their IDs."""
+        payload = self.jobs()
+        retried = []
+        now = _now()
+        for identifier, job in payload["jobs"].items():
+            if job.get("status") != "failed" or not job.get("retryable", False):
+                continue
+            if job_type and job.get("type") != job_type and identifier != job_type:
+                continue
+            job.update({"status": "pending", "updated_at": now})
+            for unit in job.get("units", {}).values():
+                if unit.get("status") == "failed" and unit.get("retryable", False):
+                    unit.update({"status": "pending", "updated_at": now})
+            retried.append(identifier)
+        if retried:
+            payload["updated_at"] = now
+            _atomic_write_json(self.jobs_path, payload)
+        return retried

--- a/src/murmur/cli.py
+++ b/src/murmur/cli.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from rich.table import Table
 
 from murmur import hooks
+from murmur.artifacts import ArtifactStore, CorruptStateError
 from murmur.recorder import (
     get_pipewire_sinks,
     get_pipewire_sources,
@@ -324,6 +325,63 @@ def status():
         console.print("[dim]Not recording.[/dim]")
 
 
+@cli.group()
+def jobs():
+    """Inspect and retry durable recording-processing jobs."""
+
+
+@jobs.command(name="status")
+@click.argument("recording", type=click.Path(exists=True, path_type=Path))
+@click.option("--json", "as_json", is_flag=True, help="Print machine-readable job state.")
+def jobs_status(recording: Path, as_json: bool):
+    """Show processing status and canonical artifacts for RECORDING."""
+    try:
+        store = ArtifactStore(recording)
+        manifest = store.ensure_manifest()
+        payload = store.jobs()
+    except CorruptStateError as error:
+        raise click.ClickException(str(error)) from error
+
+    if as_json:
+        click.echo(json.dumps({"manifest": manifest, "jobs": payload["jobs"]}, indent=2))
+        return
+
+    console.print(f"[bold]Recording:[/bold] {recording}")
+    console.print(f"[bold]Artifacts:[/bold] {store.directory}")
+    if not payload["jobs"]:
+        console.print("[dim]No processing jobs yet.[/dim]")
+        return
+
+    table = Table(title="Processing jobs")
+    table.add_column("Job", style="cyan")
+    table.add_column("Status")
+    table.add_column("Attempts", justify="right")
+    table.add_column("Last error", style="red")
+    for identifier, job in sorted(payload["jobs"].items()):
+        table.add_row(
+            identifier,
+            job.get("status", "unknown"),
+            str(job.get("attempt_count", 0)),
+            job.get("last_error") or "",
+        )
+    console.print(table)
+
+
+@jobs.command(name="retry")
+@click.argument("recording", type=click.Path(exists=True, path_type=Path))
+@click.option("--job", "job_type", help="Retry only this job type or job ID.")
+def jobs_retry(recording: Path, job_type: str | None):
+    """Reset retryable failed jobs so their processing command can resume."""
+    try:
+        retried = ArtifactStore(recording).retry_failed(job_type)
+    except CorruptStateError as error:
+        raise click.ClickException(str(error)) from error
+    if not retried:
+        console.print("[yellow]No matching retryable failed jobs.[/yellow]")
+        return
+    console.print(f"[green]Queued for retry:[/green] {', '.join(retried)}")
+
+
 @cli.command(name="import")
 @click.argument("file", type=click.Path(exists=True))
 @click.option(
@@ -360,8 +418,12 @@ def import_audio(file: str, tag: str | None):
         "original_path": str(source),
         "output": str(dest),
     }
+    store = ArtifactStore(dest)
+    meta["recording_id"] = store.recording_id
+    meta["artifacts_dir"] = str(store.directory)
     meta_path = dest.with_suffix(".json")
     meta_path.write_text(json.dumps(meta, indent=2))
+    store.ensure_manifest(meta)
 
     hooks.emit(
         "recording_saved",

--- a/src/murmur/plugins/diarize.py
+++ b/src/murmur/plugins/diarize.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 from rich.console import Console
 
+from murmur.artifacts import ArtifactStore
 from murmur.config import get_section
 
 console = Console()
@@ -21,6 +24,69 @@ def _check_dep():
             "Install with: [cyan]uv add murmur[diarize][/cyan]"
         )
         return False
+
+
+def _diarize_file(
+    file: str, token: str, speaker_names: dict[str, str] | None = None
+) -> tuple[Path, Path, set[str]]:
+    """Run pyannote and persist canonical diarization artifacts."""
+    from io import StringIO
+
+    from pyannote.audio import Pipeline
+
+    speaker_names = speaker_names or {}
+    audio_path = Path(file)
+    store = ArtifactStore(audio_path)
+    rttm_path = store.path("speakers/diarization.rttm")
+    timeline_path = store.path("speakers/diarization.txt")
+    _, should_run = store.begin_job(
+        "diarize",
+        "pyannote",
+        model="pyannote/speaker-diarization-3.1",
+        parameters={"speaker_names": list(speaker_names.values())},
+        output_paths=[rttm_path, timeline_path],
+        output_artifacts=["diarization_rttm", "diarization_timeline"],
+    )
+    if not should_run:
+        return rttm_path, timeline_path, set()
+
+    try:
+        pipeline = Pipeline.from_pretrained(
+            "pyannote/speaker-diarization-3.1", use_auth_token=token
+        )
+        diarization = pipeline(file)
+        rttm_buffer = StringIO()
+        diarization.write_rttm(rttm_buffer)
+        rttm_path = store.write_text("speakers/diarization.rttm", rttm_buffer.getvalue())
+
+        seen_speakers = set()
+        timeline = []
+        for turn, _, speaker in diarization.itertracks(yield_label=True):
+            seen_speakers.add(speaker)
+            label = speaker_names.get(speaker, speaker)
+            line = f"[{turn.start:.1f}s -> {turn.end:.1f}s] {label}"
+            timeline.append(line)
+            console.print(f"  [dim]{line}[/dim]")
+        timeline_path = store.write_text("speakers/diarization.txt", "\n".join(timeline) + "\n")
+        provenance = {
+            "provider": "pyannote",
+            "model": "pyannote/speaker-diarization-3.1",
+            "parameters": {"speaker_names": list(speaker_names.values())},
+        }
+        store.register_artifact(
+            "diarization_rttm", rttm_path, kind="speaker_timeline", provenance=provenance
+        )
+        store.register_artifact(
+            "diarization_timeline",
+            timeline_path,
+            kind="speaker_timeline_text",
+            provenance=provenance,
+        )
+        store.complete_job("diarize", "pyannote")
+        return rttm_path, timeline_path, seen_speakers
+    except Exception as error:
+        store.fail_job("diarize", "pyannote", error)
+        raise
 
 
 def register(cli: click.Group) -> None:
@@ -44,10 +110,6 @@ def register(cli: click.Group) -> None:
         if not _check_dep():
             raise SystemExit(1)
 
-        from pathlib import Path
-
-        from pyannote.audio import Pipeline
-
         cfg = get_section("diarize")
         token = hf_token or cfg.get("hf_token")
         if not token:
@@ -64,29 +126,7 @@ def register(cli: click.Group) -> None:
                 speaker_names[f"SPEAKER_{i:02d}"] = name.strip()
 
         console.print(f"[bold]Diarizing[/bold] {file}")
-
-        pipeline = Pipeline.from_pretrained(
-            "pyannote/speaker-diarization-3.1", use_auth_token=token
-        )
-        diarization = pipeline(file)
-
-        audio_path = Path(file)
-        rttm_path = audio_path.with_suffix(".rttm")
-        diarized_txt_path = audio_path.with_suffix(".diarized.txt")
-
-        # Write RTTM
-        with rttm_path.open("w") as f:
-            diarization.write_rttm(f)
-
-        # Write human-readable diarized transcript
-        seen_speakers = set()
-        with diarized_txt_path.open("w") as f:
-            for turn, _, speaker in diarization.itertracks(yield_label=True):
-                seen_speakers.add(speaker)
-                label = speaker_names.get(speaker, speaker)
-                line = f"[{turn.start:.1f}s -> {turn.end:.1f}s] {label}"
-                f.write(line + "\n")
-                console.print(f"  [dim]{line}[/dim]")
+        rttm_path, diarized_txt_path, seen_speakers = _diarize_file(file, token, speaker_names)
 
         console.print(
             f"\n[bold green]Diarization saved:[/bold green] {rttm_path}"

--- a/src/murmur/plugins/summarize.py
+++ b/src/murmur/plugins/summarize.py
@@ -10,6 +10,7 @@ import click
 from rich.console import Console
 
 from murmur import hooks
+from murmur.artifacts import ArtifactStore
 from murmur.config import get_section
 
 console = Console()
@@ -278,16 +279,61 @@ def _find_transcript(file_path):
     if file_path.suffix == ".txt":
         return file_path
 
-    transcript_path = file_path.with_suffix(".txt")
-    if transcript_path.exists():
-        return transcript_path
+    store = ArtifactStore(file_path)
+    for transcript_path in (store.path("transcript.md"), store.path("transcript.txt")):
+        if transcript_path.exists():
+            return transcript_path
+
+    legacy_path = file_path.with_suffix(".txt")
+    if legacy_path.exists():
+        return legacy_path
 
     console.print(
         f"[red]No transcript found for {file_path.name}.[/red]\n"
-        f"Expected: [cyan]{transcript_path}[/cyan]\n"
+        f"Expected a canonical transcript under: [cyan]{store.directory}[/cyan]\n"
         f"Run [cyan]murmur transcribe {file_path}[/cyan] first."
     )
     raise SystemExit(1)
+
+
+def _summarize_file(transcript_path: Path, model_name: str) -> Path:
+    """Generate and persist a summary with durable job state."""
+    transcript = transcript_path.read_text()
+    if not transcript.strip():
+        raise ValueError("Transcript is empty, nothing to summarize.")
+
+    store = ArtifactStore.for_input(transcript_path)
+    summary_path = store.path("summary.md")
+    _, should_run = store.begin_job(
+        "summarize",
+        "litellm",
+        model=model_name,
+        parameters={"prompt_version": 1},
+        input_paths=[transcript_path],
+        output_paths=[summary_path],
+        output_artifacts=["summary_markdown"],
+    )
+    if not should_run:
+        return summary_path
+
+    try:
+        summary = _llm_generate(model_name, transcript, file_path=str(transcript_path))
+        summary_path = store.write_text("summary.md", summary)
+        store.register_artifact(
+            "summary_markdown",
+            summary_path,
+            kind="meeting_summary",
+            provenance={
+                "provider": "litellm",
+                "model": model_name,
+                "parameters": {"prompt_version": 1},
+            },
+        )
+        store.complete_job("summarize", "litellm")
+        return summary_path
+    except Exception as error:
+        store.fail_job("summarize", "litellm", error)
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -332,10 +378,8 @@ def register(cli):
 
         console.print(f"[bold]Summarizing[/bold] {transcript_path} (model={model_name})")
 
-        summary = _llm_generate(model_name, transcript, file_path=str(transcript_path))
-
-        summary_path = transcript_path.with_suffix(".summary.md")
-        summary_path.write_text(summary)
+        summary_path = _summarize_file(transcript_path, model_name)
+        summary = summary_path.read_text()
 
         console.print(f"\n[bold green]Summary saved:[/bold green] {summary_path}")
         console.print(f"\n{summary}")
@@ -348,15 +392,13 @@ def register(cli):
             if not _check_dep():
                 return
             model_name = cfg.get("model", DEFAULT_MODEL)
-            transcript = Path(transcript_path).read_text()
+            transcript_path = Path(transcript_path)
+            transcript = transcript_path.read_text()
             if not transcript.strip():
                 return
 
             console.print(f"\n[bold]Auto-summarizing[/bold] {transcript_path}")
-            summary = _llm_generate(model_name, transcript, file_path=transcript_path)
-
-            summary_path = Path(transcript_path).with_suffix(".summary.md")
-            summary_path.write_text(summary)
+            summary_path = _summarize_file(transcript_path, model_name)
             console.print(f"[bold green]Auto-summary saved:[/bold green] {summary_path}")
 
         hooks.on("transcription_complete", _auto_summarize)

--- a/src/murmur/plugins/tasks_extract.py
+++ b/src/murmur/plugins/tasks_extract.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from murmur.artifacts import ArtifactStore
 from murmur.config import get_section
 
 console = Console()
@@ -207,7 +208,16 @@ def _find_input_file(file_path):
             return file_path
         raise click.ClickException(f"File not found: {file_path}")
 
-    # For audio files, look for .summary.md first, then .txt
+    store = ArtifactStore(file_path)
+    for canonical in (
+        store.path("summary.md"),
+        store.path("transcript.md"),
+        store.path("transcript.txt"),
+    ):
+        if canonical.exists():
+            return canonical
+
+    # Backward compatibility for sibling artifacts from older Murmur versions.
     summary_path = file_path.with_suffix(".summary.md")
     if summary_path.exists():
         return summary_path

--- a/src/murmur/plugins/transcribe.py
+++ b/src/murmur/plugins/transcribe.py
@@ -6,6 +6,7 @@ import click
 from rich.console import Console
 
 from murmur import hooks
+from murmur.artifacts import ArtifactStore
 from murmur.config import get_section
 
 console = Console()
@@ -34,32 +35,85 @@ def _format_srt_time(seconds: float) -> str:
 
 
 def _transcribe_file(file_path: str, model_size: str, lang: str) -> None:
-    """Run transcription on a file, producing .txt and .srt outputs."""
+    """Run local transcription into the canonical artifact directory."""
     from pathlib import Path
 
     from faster_whisper import WhisperModel
 
     console.print(f"[bold]Transcribing[/bold] {file_path} (model={model_size}, lang={lang})")
 
-    whisper = WhisperModel(model_size, compute_type="int8")
-    segments_iter, _info = whisper.transcribe(file_path, language=lang)
-
     audio_path = Path(file_path)
-    transcript_path = audio_path.with_suffix(".txt")
-    srt_path = audio_path.with_suffix(".srt")
+    store = ArtifactStore(audio_path)
+    output_names = ["transcript_raw_local", "transcript_text", "transcript_srt"]
+    transcript_path = store.path("transcript.txt")
+    srt_path = store.path("transcript.srt")
+    raw_path = store.path("raw-responses/transcribe-faster-whisper.json")
+    _, should_run = store.begin_job(
+        "transcribe",
+        "faster-whisper",
+        model=model_size,
+        parameters={"language": lang, "compute_type": "int8"},
+        output_paths=[raw_path, transcript_path, srt_path],
+        output_artifacts=output_names,
+    )
+    if not should_run:
+        console.print(f"[green]Transcript already complete:[/green] {transcript_path}")
+        hooks.emit(
+            "transcription_complete",
+            audio_path=str(audio_path),
+            transcript_path=str(transcript_path),
+        )
+        return
 
-    segments = list(segments_iter)
+    try:
+        whisper = WhisperModel(model_size, compute_type="int8")
+        segments_iter, info = whisper.transcribe(file_path, language=lang)
+        segments = list(segments_iter)
 
-    with transcript_path.open("w") as txt_f, srt_path.open("w") as srt_f:
+        text_lines = []
+        srt_blocks = []
+        raw_segments = []
         for i, segment in enumerate(segments, 1):
             line = f"[{segment.start:.1f}s -> {segment.end:.1f}s] {segment.text}"
-            txt_f.write(line + "\n")
+            text_lines.append(line)
             console.print(f"  [dim]{line}[/dim]")
+            srt_blocks.append(
+                f"{i}\n{_format_srt_time(segment.start)} --> "
+                f"{_format_srt_time(segment.end)}\n{segment.text.strip()}\n"
+            )
+            raw_segments.append(
+                {"id": i, "start": segment.start, "end": segment.end, "text": segment.text}
+            )
 
-            # SRT format
-            srt_f.write(f"{i}\n")
-            srt_f.write(f"{_format_srt_time(segment.start)} --> {_format_srt_time(segment.end)}\n")
-            srt_f.write(f"{segment.text.strip()}\n\n")
+        raw_path = store.write_json(
+            "raw-responses/transcribe-faster-whisper.json",
+            {
+                "provider": "faster-whisper",
+                "model": model_size,
+                "language": getattr(info, "language", lang),
+                "segments": raw_segments,
+            },
+        )
+        transcript_path = store.write_text("transcript.txt", "\n".join(text_lines) + "\n")
+        srt_path = store.write_text("transcript.srt", "\n".join(srt_blocks))
+        provenance = {
+            "provider": "faster-whisper",
+            "model": model_size,
+            "parameters": {"language": lang, "compute_type": "int8"},
+        }
+        store.register_artifact(
+            "transcript_raw_local", raw_path, kind="raw_provider_response", provenance=provenance
+        )
+        store.register_artifact(
+            "transcript_text", transcript_path, kind="transcript", provenance=provenance
+        )
+        store.register_artifact(
+            "transcript_srt", srt_path, kind="subtitles", provenance=provenance
+        )
+        store.complete_job("transcribe", "faster-whisper")
+    except Exception as error:
+        store.fail_job("transcribe", "faster-whisper", error)
+        raise
 
     hooks.emit(
         "transcription_complete",

--- a/src/murmur/plugins/tui.py
+++ b/src/murmur/plugins/tui.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import click
 from rich.text import Text
 
+from murmur.artifacts import ArtifactStore
 from murmur.config import get_section
 from murmur.recorder import (
     _default_output_dir,
@@ -56,17 +57,29 @@ def _get_duration(rec: Path) -> str:
     return "\u2014"
 
 
-def _artifact_exists(rec: Path, suffix: str) -> bool:
+def _artifact_path(rec: Path, suffix: str) -> Path:
+    canonical = {
+        ".txt": "transcript.txt",
+        ".srt": "transcript.srt",
+        ".summary.md": "summary.md",
+        ".diarized.txt": "speakers/diarization.txt",
+        ".rttm": "speakers/diarization.rttm",
+    }
+    if suffix in canonical:
+        path = ArtifactStore(rec).path(canonical[suffix])
+        if path.exists():
+            return path
     if suffix == ".summary.md":
-        return rec.with_suffix("").with_suffix(".summary.md").exists()
-    return rec.with_suffix(suffix).exists()
+        return rec.with_suffix("").with_suffix(".summary.md")
+    return rec.with_suffix(suffix)
+
+
+def _artifact_exists(rec: Path, suffix: str) -> bool:
+    return _artifact_path(rec, suffix).exists()
 
 
 def _read_artifact(rec: Path, suffix: str) -> str | None:
-    if suffix == ".summary.md":
-        path = rec.with_suffix("").with_suffix(".summary.md")
-    else:
-        path = rec.with_suffix(suffix)
+    path = _artifact_path(rec, suffix)
     if not path.exists():
         return None
     return path.read_text()
@@ -437,7 +450,7 @@ def _build_app(audio_format: str):
                 from murmur.plugins.summarize import (
                     DEFAULT_MODEL,
                     _find_transcript,
-                    _llm_generate,
+                    _summarize_file,
                 )
 
                 cfg = get_section("summarize")
@@ -447,9 +460,9 @@ def _build_app(audio_format: str):
                 if not transcript.strip():
                     self.notify("Transcript is empty", severity="warning")
                     return
-                summary = await self._run_in_thread(_llm_generate, model_name, transcript)
-                summary_path = transcript_path.with_suffix(".summary.md")
-                summary_path.write_text(summary)
+                summary_path = await self._run_in_thread(
+                    _summarize_file, transcript_path, model_name
+                )
                 self.notify(f"Summary ready: {summary_path.name}")
             except SystemExit:
                 self.notify(
@@ -465,7 +478,7 @@ def _build_app(audio_format: str):
         async def _run_diarize(self, rec: Path) -> None:
             """Run diarization in a background worker."""
             try:
-                from murmur.plugins.diarize import _check_dep
+                from murmur.plugins.diarize import _check_dep, _diarize_file
 
                 if not _check_dep():
                     self.notify(
@@ -485,22 +498,7 @@ def _build_app(audio_format: str):
                     )
                     return
 
-                from pyannote.audio import Pipeline
-
-                pipeline = await self._run_in_thread(
-                    Pipeline.from_pretrained,
-                    "pyannote/speaker-diarization-3.1",
-                    use_auth_token=token,
-                )
-                diarization = await self._run_in_thread(pipeline, str(rec))
-
-                rttm_path = rec.with_suffix(".rttm")
-                diarized_path = rec.with_suffix(".diarized.txt")
-                with rttm_path.open("w") as f:
-                    diarization.write_rttm(f)
-                with diarized_path.open("w") as f:
-                    for turn, _, speaker in diarization.itertracks(yield_label=True):
-                        f.write(f"[{turn.start:.1f}s -> {turn.end:.1f}s] {speaker}\n")
+                _, diarized_path, _ = await self._run_in_thread(_diarize_file, str(rec), token)
 
                 self.notify(f"Diarization ready: {diarized_path.name}")
             except Exception as e:

--- a/src/murmur/recorder.py
+++ b/src/murmur/recorder.py
@@ -282,8 +282,15 @@ def _finalize_recording(meta: dict[str, Any], error: str | None = None) -> dict[
         finalized["status"] = "failed"
         finalized["error"] = error or "FFmpeg did not produce a valid media file."
 
+    if finalized["status"] == "recorded":
+        from murmur.artifacts import ArtifactStore
+
+        store = ArtifactStore(output_path)
+        finalized["recording_id"] = store.recording_id
+        finalized["artifacts_dir"] = str(store.directory)
     _write_json_atomic(meta_path, finalized)
     if finalized["status"] == "recorded":
+        store.ensure_manifest(finalized)
         hooks.emit(
             "recording_saved",
             output_path=str(output_path),

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,225 @@
+"""Tests for canonical artifacts and durable processing jobs."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from murmur import artifacts
+from murmur.artifacts import ArtifactStore, CorruptStateError
+
+
+def _recording(tmp_path, name="meeting.mka", content=b"recording"):
+    path = tmp_path / "recordings" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def test_ensure_manifest_creates_canonical_layout(tmp_path):
+    recording = _recording(tmp_path)
+    store = ArtifactStore(recording, root=tmp_path / "artifacts")
+
+    manifest = store.ensure_manifest(
+        {
+            "format": "mka",
+            "duration_secs": 12.5,
+            "streams": [{"index": 0, "title": "Mixed call"}],
+        }
+    )
+
+    assert store.directory == tmp_path / "artifacts" / "meeting"
+    assert store.manifest_path.exists()
+    assert store.jobs_path.exists()
+    assert manifest["recording"] == str(recording.resolve())
+    assert manifest["source_fingerprint"]["algorithm"] == "sha256"
+    assert manifest["media"]["duration_secs"] == 12.5
+    assert manifest["media"]["streams"][0]["title"] == "Mixed call"
+    assert json.loads(store.jobs_path.read_text())["jobs"] == {}
+
+
+def test_manifest_reuses_fingerprint_for_unchanged_source(tmp_path):
+    recording = _recording(tmp_path)
+    store = ArtifactStore(recording, root=tmp_path / "artifacts")
+    first = store.ensure_manifest()
+
+    with patch.object(artifacts, "fingerprint_file", wraps=artifacts.fingerprint_file) as digest:
+        second = store.ensure_manifest()
+
+    digest.assert_not_called()
+    assert second["source_fingerprint"] == first["source_fingerprint"]
+
+
+def test_register_artifact_tracks_checksum_and_sanitizes_provenance(tmp_path):
+    recording = _recording(tmp_path)
+    store = ArtifactStore(recording, root=tmp_path / "artifacts")
+    store.ensure_manifest()
+    transcript = store.write_text("transcript.md", "hello")
+
+    entry = store.register_artifact(
+        "transcript_markdown",
+        transcript,
+        kind="transcript",
+        provenance={
+            "provider": "openai",
+            "api_key": "sk-secretvalue123",
+            "reference": "data:audio/wav;base64,secret",
+            "message": "Bearer secret-token-value",
+        },
+    )
+
+    persisted = store.manifest_path.read_text()
+    assert entry["path"] == "transcript.md"
+    assert store.artifact_valid("transcript_markdown")
+    assert "sk-secretvalue123" not in persisted
+    assert "base64,secret" not in persisted
+    assert "secret-token-value" not in persisted
+
+
+def test_completed_job_skips_valid_output_and_resumes_corrupt_output(tmp_path):
+    recording = _recording(tmp_path)
+    store = ArtifactStore(recording, root=tmp_path / "artifacts")
+    output = store.write_text("transcript.md", "hello")
+    store.register_artifact("transcript_markdown", output, kind="transcript")
+    store.begin_job("transcribe", "openai", output_artifacts=["transcript_markdown"])
+    store.complete_job("transcribe", "openai")
+
+    completed, should_run = store.begin_job(
+        "transcribe", "openai", output_artifacts=["transcript_markdown"]
+    )
+    assert should_run is False
+    assert completed["attempt_count"] == 1
+
+    output.write_text("changed")
+    resumed, should_run = store.begin_job(
+        "transcribe", "openai", output_artifacts=["transcript_markdown"]
+    )
+    assert should_run is True
+    assert resumed["attempt_count"] == 2
+
+
+def test_source_change_invalidates_completed_job(tmp_path):
+    recording = _recording(tmp_path, content=b"first")
+    store = ArtifactStore(recording, root=tmp_path / "artifacts")
+    output = store.write_text("summary.md", "summary")
+    store.register_artifact("summary", output, kind="summary")
+    store.begin_job(
+        "summarize",
+        "test",
+        output_paths=[output],
+        output_artifacts=["summary"],
+    )
+    store.complete_job("summarize", "test")
+
+    recording.write_bytes(b"different source")
+    job, should_run = store.begin_job(
+        "summarize", "test", output_paths=[output], output_artifacts=["summary"]
+    )
+
+    assert should_run is True
+    assert job["attempt_count"] == 2
+    assert job["output_paths"] == [str(output)]
+
+
+def test_failed_job_survives_restart_and_can_be_retried(tmp_path):
+    recording = _recording(tmp_path)
+    root = tmp_path / "artifacts"
+    store = ArtifactStore(recording, root=root)
+    store.begin_job("transcribe", "openai", parameters={"token": "never-store-this"})
+    store.fail_job(
+        "transcribe",
+        "openai",
+        "request failed with sk-secretvalue123",
+        retryable=True,
+    )
+
+    restarted = ArtifactStore(recording, root=root)
+    failed = restarted.jobs()["jobs"]["transcribe:openai"]
+    assert failed["status"] == "failed"
+    assert failed["attempt_count"] == 1
+    assert "secretvalue" not in restarted.jobs_path.read_text()
+    assert restarted.retry_failed() == ["transcribe:openai"]
+    assert restarted.jobs()["jobs"]["transcribe:openai"]["status"] == "pending"
+
+
+def test_completed_units_survive_restart_and_are_not_resubmitted(tmp_path):
+    recording = _recording(tmp_path)
+    root = tmp_path / "artifacts"
+    store = ArtifactStore(recording, root=root)
+    store.begin_job("transcribe", "openai")
+    raw = store.write_json("raw-responses/chunk-0000.json", {"text": "done"})
+    store.register_artifact("chunk_0000_raw", raw, kind="raw_provider_response")
+    store.begin_unit(
+        "transcribe",
+        "openai",
+        "chunk-0000",
+        output_artifacts=["chunk_0000_raw"],
+    )
+    store.complete_unit("transcribe", "openai", "chunk-0000")
+
+    restarted = ArtifactStore(recording, root=root)
+    unit, should_submit = restarted.begin_unit(
+        "transcribe",
+        "openai",
+        "chunk-0000",
+        output_artifacts=["chunk_0000_raw"],
+    )
+
+    assert should_submit is False
+    assert unit["status"] == "complete"
+    assert unit["attempt_count"] == 1
+
+
+def test_running_job_state_survives_process_restart(tmp_path):
+    recording = _recording(tmp_path)
+    root = tmp_path / "artifacts"
+    ArtifactStore(recording, root=root).begin_job("transcribe", "openai")
+
+    restarted = ArtifactStore(recording, root=root)
+
+    assert restarted.jobs()["jobs"]["transcribe:openai"]["status"] == "running"
+
+
+def test_atomic_write_preserves_previous_state_on_replace_failure(tmp_path):
+    target = tmp_path / "state.json"
+    artifacts._atomic_write_json(target, {"state": "old"})
+
+    with (
+        patch.object(artifacts.os, "replace", side_effect=OSError("interrupted")),
+        pytest.raises(OSError, match="interrupted"),
+    ):
+        artifacts._atomic_write_json(target, {"state": "new"})
+
+    assert json.loads(target.read_text()) == {"state": "old"}
+    assert list(tmp_path.glob(".*.tmp")) == []
+
+
+def test_corrupted_jobs_file_is_reported(tmp_path):
+    recording = _recording(tmp_path)
+    store = ArtifactStore(recording, root=tmp_path / "artifacts")
+    store.ensure_manifest()
+    store.jobs_path.write_text("not-json")
+
+    with pytest.raises(CorruptStateError, match="Could not read"):
+        store.jobs()
+
+
+def test_artifact_paths_cannot_escape_store(tmp_path):
+    recording = _recording(tmp_path)
+    store = ArtifactStore(recording, root=tmp_path / "artifacts")
+
+    with pytest.raises(ValueError, match="inside"):
+        store.path("../escape.json")
+
+
+def test_same_stem_recordings_get_distinct_stores(tmp_path):
+    first = _recording(tmp_path / "one")
+    second = _recording(tmp_path / "two")
+    root = tmp_path / "artifacts"
+    first_store = ArtifactStore(first, root=root)
+    first_store.ensure_manifest()
+    second_store = ArtifactStore(second, root=root)
+    second_store.ensure_manifest()
+
+    assert first_store.directory != second_store.directory
+    assert second_store.recording_id.startswith("meeting-")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,11 @@
 """Tests for CLI commands using Click's test runner."""
 
+import json
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
+from murmur.artifacts import ArtifactStore
 from murmur.cli import cli
 
 runner = CliRunner()
@@ -175,3 +177,30 @@ def test_start_with_mic_uses_multitrack_mka(tmp_path):
         mic_source="alsa_input.mic",
         mic_id=58,
     )
+
+
+def test_jobs_status_creates_and_prints_canonical_state(tmp_path):
+    recording = tmp_path / "meeting.flac"
+    recording.write_bytes(b"audio")
+
+    result = runner.invoke(cli, ["jobs", "status", str(recording), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["manifest"]["recording"] == str(recording.resolve())
+    assert payload["jobs"] == {}
+    assert (tmp_path / "artifacts" / "meeting" / "manifest.json").exists()
+
+
+def test_jobs_retry_resets_failed_job(tmp_path):
+    recording = tmp_path / "meeting.flac"
+    recording.write_bytes(b"audio")
+    store = ArtifactStore(recording)
+    store.begin_job("transcribe", "openai")
+    store.fail_job("transcribe", "openai", "temporary failure")
+
+    result = runner.invoke(cli, ["jobs", "retry", str(recording), "--job", "transcribe"])
+
+    assert result.exit_code == 0
+    assert "transcribe:openai" in result.output
+    assert store.jobs()["jobs"]["transcribe:openai"]["status"] == "pending"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,10 +1,14 @@
 """Tests for plugin registration and discovery."""
 
+import json
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 
 import click
 from click.testing import CliRunner
 
+from murmur.artifacts import ArtifactStore
 from murmur.plugins import diarize, summarize, transcribe, tui
 from murmur.plugins.transcribe import _format_srt_time
 
@@ -106,3 +110,94 @@ def test_summarize_missing_transcript(tmp_path):
 
     with pytest.raises(SystemExit):
         summarize._find_transcript(audio)
+
+
+def test_local_transcription_persists_artifacts_and_resumes(tmp_path):
+    audio = tmp_path / "meeting.flac"
+    audio.write_bytes(b"audio")
+    segments = [
+        SimpleNamespace(start=0.0, end=1.5, text=" Hello"),
+        SimpleNamespace(start=1.5, end=3.0, text=" world"),
+    ]
+
+    class FakeWhisperModel:
+        calls = 0
+
+        def __init__(self, model, compute_type):
+            self.model = model
+            self.compute_type = compute_type
+
+        def transcribe(self, file, language):
+            type(self).calls += 1
+            return iter(segments), SimpleNamespace(language=language)
+
+    fake_module = ModuleType("faster_whisper")
+    fake_module.WhisperModel = FakeWhisperModel
+    with (
+        patch.dict(sys.modules, {"faster_whisper": fake_module}),
+        patch.object(transcribe.hooks, "emit"),
+    ):
+        transcribe._transcribe_file(str(audio), "base", "en")
+        transcribe._transcribe_file(str(audio), "base", "en")
+
+    artifact_dir = tmp_path / "artifacts" / "meeting"
+    assert (artifact_dir / "transcript.txt").read_text().endswith("world\n")
+    assert (artifact_dir / "transcript.srt").read_text().startswith("1\n00:00:00,000")
+    assert (artifact_dir / "raw-responses/transcribe-faster-whisper.json").exists()
+    jobs = json.loads((artifact_dir / "jobs.json").read_text())["jobs"]
+    assert jobs["transcribe:faster-whisper"]["status"] == "complete"
+    assert FakeWhisperModel.calls == 1
+
+
+def test_diarization_persists_canonical_outputs(tmp_path):
+    audio = tmp_path / "meeting.flac"
+    audio.write_bytes(b"audio")
+
+    class FakeDiarization:
+        def write_rttm(self, handle):
+            handle.write("SPEAKER meeting 1 0.000 1.000 <NA> <NA> SPEAKER_00 <NA> <NA>\n")
+
+        def itertracks(self, yield_label=False):
+            yield SimpleNamespace(start=0.0, end=1.0), None, "SPEAKER_00"
+
+    class FakePipeline:
+        @classmethod
+        def from_pretrained(cls, model, use_auth_token):
+            return cls()
+
+        def __call__(self, file):
+            return FakeDiarization()
+
+    pyannote = ModuleType("pyannote")
+    pyannote_audio = ModuleType("pyannote.audio")
+    pyannote_audio.Pipeline = FakePipeline
+    pyannote.audio = pyannote_audio
+
+    with patch.dict(sys.modules, {"pyannote": pyannote, "pyannote.audio": pyannote_audio}):
+        rttm, timeline, speakers = diarize._diarize_file(
+            str(audio), "hf_never_persist", {"SPEAKER_00": "Rohan"}
+        )
+
+    assert rttm.parent.name == "speakers"
+    assert "SPEAKER_00" in rttm.read_text()
+    assert "Rohan" in timeline.read_text()
+    assert speakers == {"SPEAKER_00"}
+    assert "hf_never_persist" not in (tmp_path / "artifacts/meeting/jobs.json").read_text()
+
+
+def test_summary_persists_and_skips_valid_completed_output(tmp_path):
+    audio = tmp_path / "meeting.flac"
+    audio.write_bytes(b"audio")
+    store = ArtifactStore(audio)
+    store.ensure_manifest()
+    transcript_path = store.write_text("transcript.txt", "A useful meeting transcript")
+    store.register_artifact("transcript_text", transcript_path, kind="transcript")
+
+    with patch.object(summarize, "_llm_generate", return_value="# Summary") as generate:
+        first = summarize._summarize_file(transcript_path, "test/model")
+        second = summarize._summarize_file(transcript_path, "test/model")
+
+    assert first == second == store.path("summary.md")
+    assert first.read_text() == "# Summary"
+    generate.assert_called_once()
+    assert store.jobs()["jobs"]["summarize:litellm"]["status"] == "complete"

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -359,6 +359,9 @@ def test_finalize_recording_uses_ffprobe_metadata(tmp_path):
     assert finalized["duration_secs"] == 12.5
     assert finalized["file_size_bytes"] == 5
     assert finalized["streams"] == probe["streams"]
+    assert finalized["recording_id"] == "meeting"
+    assert (tmp_path / "artifacts/meeting/manifest.json").exists()
+    assert (tmp_path / "artifacts/meeting/jobs.json").exists()
     assert json.loads(output.with_suffix(".json").read_text())["status"] == "recorded"
     emit.assert_called_once_with(
         "recording_saved",


### PR DESCRIPTION
## What

- add a canonical artifact store with manifest, source fingerprint, media metadata, and inventory
- persist atomic `pending | running | failed | complete` job and chunk-unit state
- checksum completed outputs before skipping them during resume
- retain raw local transcription responses separately from rendered outputs
- move transcription, diarization, summaries, TUI reads, and task inputs to canonical paths
- add `murmur jobs status` and `murmur jobs retry`
- redact credentials, `op://` references, bearer tokens, and audio data URLs from persisted state

## Why

Sibling files and process-local hooks could not safely resume long jobs or explain which source/model produced an artifact.

## Verification

- full suite: 80 passed
- Ruff lint and format passed
- tests cover atomic interruption, restart recovery, completed-unit resume, source/artifact corruption, collisions, provenance, redaction, and CLI retry

Closes #21