### PR TITLE
feat: add resumable OpenAI transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ uv pip install murmur[ai]
 # With transcription (faster-whisper)
 uv pip install murmur[transcribe]
 
+# With OpenAI cloud transcription
+uv pip install murmur[cloud]
+
 # Everything
 uv pip install murmur[all]
 
@@ -85,7 +88,7 @@ murmur watch
 # Auto-record when a meeting is detected
 murmur watch --auto-record
 
-# Auto-record with mic input (dual-channel: system left, mic right)
+# Auto-record with a listening mix plus separate mic and call-output tracks
 murmur watch --auto-record --mic
 
 # Faster polling (default: 5s)
@@ -131,8 +134,12 @@ apps = ["chrome", "firefox", "zoom", "teams", "slack", "discord"]
 
 [transcribe]
 auto = true          # auto-transcribe after recording
+provider = "local"   # local or openai
 model = "base"       # whisper model size
+openai_model = "gpt-4o-transcribe"
 language = "en"
+chunk_seconds = 600
+overlap_seconds = 2
 
 [summarize]
 auto = true          # auto-summarize after transcription
@@ -171,6 +178,26 @@ Job metadata records provider and model parameters but removes credentials and
 embedded audio data. Raw provider responses are kept separately from derived
 transcripts and summaries.
 
+### OpenAI cloud transcription
+
+OpenAI uploads are limited to 25 MB, so Murmur extracts the selected mixed
+stream into lossless 16 kHz mono WAV chunks, submits them sequentially, and
+writes every response before continuing. The default ten-minute chunks remain
+below the limit while a short overlap protects boundary words.
+
+```bash
+# Standard environment variable
+OPENAI_API_KEY=... murmur transcribe meeting.mka --provider openai
+
+# 1Password reference without placing the secret in config or shell history
+OPENAI_API_KEY='op://Personal/OPENAI_API_KEY/credential' \
+  op run -- murmur transcribe meeting.mka --provider openai --resume
+```
+
+Resume is enabled by default; use `--restart` only when you intentionally want
+to submit every chunk again. The source recording is opened read-only and is
+never rewritten.
+
 ## Plugins
 
 | Plugin | Command | What it does | Install |
@@ -179,7 +206,7 @@ transcripts and summaries.
 | **memory** | `murmur memory` | Personal context for LLM summaries | built-in |
 | **tui** | `murmur tui` | Live dashboard with artifact viewer + generation | `murmur[tui]` |
 | **summarize** | `murmur summarize <file>` | DSPy structured summarization → `.summary.md` | `murmur[ai]` |
-| **transcribe** | `murmur transcribe <file>` | Whisper transcription → `.txt` + `.srt` | `murmur[transcribe]` |
+| **transcribe** | `murmur transcribe <file>` | Local or resumable OpenAI transcription | `murmur[transcribe]` / `murmur[cloud]` |
 | **diarize** | `murmur diarize <file>` | Speaker diarization → `.rttm` + `.diarized.txt` | `murmur[diarize]` |
 
 ## Development
@@ -205,7 +232,7 @@ the private process in [SECURITY.md](SECURITY.md).
 
 ## Roadmap
 
-- [ ] Automatic transcription (Whisper local / Deepgram API)
+- [x] Automatic transcription (local Whisper / OpenAI)
 - [ ] Speaker diarization
 - [x] Auto-detect meeting apps and start recording
 - [ ] Web UI for browsing/searching recordings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 tui = ["textual>=8.1.1"]
 ai = ["dspy>=3.1.3", "litellm==1.82.4"]
 transcribe = ["faster-whisper>=1.0.0"]
+cloud = ["openai>=1.0"]
 diarize = ["pyannote-audio>=3.0", "torch"]
 calendar = [
     "google-api-python-client>=2.0",
@@ -22,7 +23,7 @@ calendar = [
 tasks = ["murmur[ai]"]
 tasks-tw = ["tasklib>=2.0"]
 all = [
-    "murmur[tui]", "murmur[ai]", "murmur[transcribe]", "murmur[diarize]",
+    "murmur[tui]", "murmur[ai]", "murmur[transcribe]", "murmur[cloud]", "murmur[diarize]",
     "murmur[calendar]", "murmur[tasks]", "murmur[tasks-tw]",
 ]
 dev = ["murmur[all]", "pytest>=8.0", "pytest-cov>=6.0", "mypy>=1.10", "bandit>=1.7", "ruff>=0.11", "pre-commit>=4.0"]

--- a/src/murmur/artifacts.py
+++ b/src/murmur/artifacts.py
@@ -161,9 +161,12 @@ class ArtifactStore:
         _atomic_write_text(output, content)
         return output
 
-    def write_json(self, relative: str | Path, payload: dict[str, Any]) -> Path:
+    def write_json(
+        self, relative: str | Path, payload: dict[str, Any], *, sanitize: bool = False
+    ) -> Path:
         output = self.path(relative)
-        _atomic_write_json(output, payload)
+        persisted = _sanitize(payload) if sanitize else payload
+        _atomic_write_json(output, persisted)
         return output
 
     def _source_fingerprint(self, previous: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -386,6 +389,7 @@ class ArtifactStore:
         *,
         parameters: dict[str, Any] | None = None,
         output_artifacts: list[str] | None = None,
+        resume: bool = True,
     ) -> tuple[dict[str, Any], bool]:
         """Start one resumable job unit, skipping checksum-valid completed work."""
         payload = self.jobs()
@@ -397,7 +401,8 @@ class ArtifactStore:
         previous = units.get(unit_id, {})
         outputs = output_artifacts or []
         if (
-            previous.get("status") == "complete"
+            resume
+            and previous.get("status") == "complete"
             and outputs
             and all(self.artifact_valid(name) for name in outputs)
         ):

--- a/src/murmur/cloud_transcribe.py
+++ b/src/murmur/cloud_transcribe.py
@@ -1,0 +1,543 @@
+"""Resumable OpenAI transcription for long recording files."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from murmur.artifacts import ArtifactStore
+
+DEFAULT_MODEL = "gpt-4o-transcribe"
+DEFAULT_CHUNK_SECONDS = 600.0
+DEFAULT_OVERLAP_SECONDS = 2.0
+MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+SAFE_UPLOAD_BYTES = 24 * 1024 * 1024
+ARTIFACT_TEXT = re.compile(
+    r"^\s*[\[(](?:music|silence|inaudible|applause|noise)[\])]\s*$", re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class Chunk:
+    index: int
+    start: float
+    duration: float
+
+    @property
+    def end(self) -> float:
+        return self.start + self.duration
+
+    @property
+    def unit_id(self) -> str:
+        return f"chunk-{self.index:04d}"
+
+
+class TranscriptionProviderError(RuntimeError):
+    """An inspectable provider error with retry guidance."""
+
+    def __init__(self, message: str, *, retryable: bool) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True)  # noqa: S603
+
+
+def _media_duration(recording: Path) -> float:
+    ffprobe = shutil.which("ffprobe")
+    if ffprobe is None:
+        raise RuntimeError("ffprobe is required for cloud transcription.")
+    result = _run(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "json",
+            str(recording),
+        ]
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Could not inspect recording: {result.stderr.strip()}")
+    try:
+        return float(json.loads(result.stdout)["format"]["duration"])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        raise RuntimeError("ffprobe did not return a valid recording duration.") from error
+
+
+def _select_audio_stream(manifest: dict[str, Any]) -> int:
+    """Prefer the named mixed/default stream, then the first audio stream."""
+    streams = manifest.get("media", {}).get("streams", [])
+    audio_streams = [stream for stream in streams if stream.get("codec_type", "audio") == "audio"]
+    for stream in audio_streams:
+        if stream.get("source_role") == "mixed" or stream.get("title") == "Mixed call":
+            return int(stream.get("index", 0))
+    for stream in audio_streams:
+        if stream.get("default") or stream.get("disposition", {}).get("default") == 1:
+            return int(stream.get("index", 0))
+    return int(audio_streams[0].get("index", 0)) if audio_streams else 0
+
+
+def plan_chunks(
+    duration: float,
+    chunk_seconds: float = DEFAULT_CHUNK_SECONDS,
+    overlap_seconds: float = DEFAULT_OVERLAP_SECONDS,
+) -> list[Chunk]:
+    if duration <= 0:
+        raise ValueError("Recording duration must be positive.")
+    if chunk_seconds <= 0 or overlap_seconds < 0 or overlap_seconds >= chunk_seconds:
+        raise ValueError("Chunk duration must be positive and greater than the overlap.")
+    chunks = []
+    start = 0.0
+    step = chunk_seconds - overlap_seconds
+    while start < duration:
+        chunks.append(
+            Chunk(
+                index=len(chunks),
+                start=round(start, 6),
+                duration=round(min(chunk_seconds, duration - start), 6),
+            )
+        )
+        start += step
+    return chunks
+
+
+def _extract_chunk(recording: Path, output: Path, chunk: Chunk, stream_index: int) -> None:
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError("ffmpeg is required for cloud transcription.")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    result = _run(
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-ss",
+            str(chunk.start),
+            "-i",
+            str(recording),
+            "-t",
+            str(chunk.duration),
+            "-map",
+            f"0:{stream_index}",
+            "-vn",
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-c:a",
+            "pcm_s16le",
+            str(output),
+        ]
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Could not create {chunk.unit_id}: {result.stderr.strip()}")
+    if not output.is_file() or output.stat().st_size == 0:
+        raise RuntimeError(f"FFmpeg created an empty chunk: {output}")
+    if output.stat().st_size >= MAX_UPLOAD_BYTES:
+        raise RuntimeError(
+            f"{output.name} is {output.stat().st_size} bytes; reduce --chunk-seconds "
+            "to remain below OpenAI's 25 MB upload limit."
+        )
+
+
+def _response_payload(response: Any) -> dict[str, Any]:
+    if isinstance(response, dict):
+        return response
+    if hasattr(response, "model_dump"):
+        payload = response.model_dump(mode="json")
+        if isinstance(payload, dict):
+            return payload
+    if hasattr(response, "json"):
+        payload = json.loads(response.json())
+        if isinstance(payload, dict):
+            return payload
+    text = getattr(response, "text", None)
+    if text is not None:
+        return {"text": text}
+    raise TypeError("OpenAI returned an unsupported transcription response.")
+
+
+def _retryable_error(error: Exception) -> bool:
+    retryable = getattr(error, "retryable", None)
+    if isinstance(retryable, bool):
+        return retryable
+    status = getattr(error, "status_code", None)
+    if status is None:
+        return True
+    try:
+        numeric_status = int(status)
+    except TypeError, ValueError:
+        return True
+    return numeric_status in (408, 409, 429) or numeric_status >= 500
+
+
+def _error_payload(error: Exception) -> dict[str, Any]:
+    return {
+        "type": type(error).__name__,
+        "message": str(error),
+        "status_code": getattr(error, "status_code", None),
+        "request_id": getattr(error, "request_id", None),
+        "retryable": _retryable_error(error),
+    }
+
+
+def _submit_chunk(
+    client: Any,
+    chunk_path: Path,
+    *,
+    model: str,
+    language: str | None,
+    prompt: str | None,
+) -> dict[str, Any]:
+    request: dict[str, Any] = {"model": model, "response_format": "json"}
+    if language:
+        request["language"] = language
+    if prompt:
+        request["prompt"] = prompt
+    with chunk_path.open("rb") as audio:
+        response = client.audio.transcriptions.create(file=audio, **request)
+    return _response_payload(response)
+
+
+def _artifact_segment(text: str) -> bool:
+    return not text.strip() or bool(ARTIFACT_TEXT.fullmatch(text))
+
+
+def _dedupe_boundary(previous: str, current: str, max_words: int = 80) -> str:
+    """Remove the longest repeated word suffix/prefix at a chunk boundary."""
+    previous_words = previous.split()
+    current_words = current.split()
+    maximum = min(max_words, len(previous_words), len(current_words))
+    for count in range(maximum, 2, -1):
+        left = [re.sub(r"\W+", "", word).casefold() for word in previous_words[-count:]]
+        right = [re.sub(r"\W+", "", word).casefold() for word in current_words[:count]]
+        if left == right:
+            return " ".join(current_words[count:])
+    return current.strip()
+
+
+def _segments_from_response(payload: dict[str, Any], chunk: Chunk) -> list[dict[str, Any]]:
+    raw_segments = payload.get("segments")
+    if not isinstance(raw_segments, list):
+        raw_segments = [
+            {
+                "id": f"{chunk.unit_id}:0",
+                "start": 0.0,
+                "end": chunk.duration,
+                "text": payload.get("text", ""),
+            }
+        ]
+    normalized = []
+    for index, segment in enumerate(raw_segments):
+        text = str(segment.get("text", "")).strip()
+        if _artifact_segment(text):
+            continue
+        local_start = max(0.0, float(segment.get("start", 0.0)))
+        local_end = min(chunk.duration, float(segment.get("end", chunk.duration)))
+        if local_end <= local_start:
+            continue
+        normalized.append(
+            {
+                "id": str(segment.get("id", f"{chunk.unit_id}:{index}")),
+                "chunk_index": chunk.index,
+                "start": round(chunk.start + local_start, 3),
+                "end": round(chunk.start + local_end, 3),
+                "text": text,
+            }
+        )
+    return normalized
+
+
+def _merge_responses(responses: list[tuple[Chunk, dict[str, Any]]]) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = []
+    for chunk, response in responses:
+        incoming = _segments_from_response(response, chunk)
+        if merged and incoming:
+            incoming[0]["text"] = _dedupe_boundary(merged[-1]["text"], incoming[0]["text"])
+            incoming[0]["start"] = max(incoming[0]["start"], merged[-1]["end"])
+            if (
+                _artifact_segment(incoming[0]["text"])
+                or incoming[0]["end"] <= incoming[0]["start"]
+            ):
+                incoming.pop(0)
+        merged.extend(incoming)
+    for index, segment in enumerate(merged, 1):
+        segment["id"] = f"segment-{index:06d}"
+    return merged
+
+
+def _clock(seconds: float, *, srt: bool = False) -> str:
+    millis = round(seconds * 1000)
+    hours, remainder = divmod(millis, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    secs, ms = divmod(remainder, 1000)
+    separator = "," if srt else "."
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}{separator}{ms:03d}"
+
+
+def _render_markdown(segments: list[dict[str, Any]]) -> str:
+    lines = ["# Transcript", ""]
+    lines.extend(f"[{_clock(segment['start'])}] {segment['text']}" for segment in segments)
+    return "\n".join(lines) + "\n"
+
+
+def _render_srt(segments: list[dict[str, Any]]) -> str:
+    blocks = []
+    for index, segment in enumerate(segments, 1):
+        blocks.append(
+            f"{index}\n{_clock(segment['start'], srt=True)} --> "
+            f"{_clock(segment['end'], srt=True)}\n{segment['text']}\n"
+        )
+    return "\n".join(blocks)
+
+
+def _load_raw(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text())
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected a JSON object in {path}.")
+    return payload
+
+
+def transcribe_openai(
+    recording: str | Path,
+    *,
+    model: str = DEFAULT_MODEL,
+    language: str | None = None,
+    prompt: str | None = None,
+    chunk_seconds: float = DEFAULT_CHUNK_SECONDS,
+    overlap_seconds: float = DEFAULT_OVERLAP_SECONDS,
+    resume: bool = True,
+    client: Any | None = None,
+) -> dict[str, Any]:
+    """Transcribe a recording sequentially with durable chunk-level resume."""
+    recording_path = Path(recording).expanduser().resolve()
+    store = ArtifactStore(recording_path)
+    manifest = store.ensure_manifest()
+    duration = float(
+        manifest.get("media", {}).get("duration_secs") or _media_duration(recording_path)
+    )
+    chunks = plan_chunks(duration, chunk_seconds, overlap_seconds)
+    stream_index = _select_audio_stream(manifest)
+    final_names = [
+        "transcript_raw",
+        "transcript_json",
+        "transcript_markdown",
+        "transcript_srt",
+    ]
+    final_paths = [
+        store.path("transcript.raw.json"),
+        store.path("transcript.json"),
+        store.path("transcript.md"),
+        store.path("transcript.srt"),
+    ]
+    job_parameters = {
+        "chunk_seconds": chunk_seconds,
+        "overlap_seconds": overlap_seconds,
+        "stream_index": stream_index,
+        "sequential": True,
+        "max_upload_bytes": MAX_UPLOAD_BYTES,
+    }
+    if language is not None:
+        job_parameters["language"] = language
+    if prompt is not None:
+        job_parameters["prompt"] = prompt
+    previous_job = store.jobs().get("jobs", {}).get("transcribe:openai", {})
+    compatible_resume = bool(
+        resume
+        and previous_job.get("model") == model
+        and previous_job.get("parameters") == job_parameters
+    )
+    _, should_run = store.begin_job(
+        "transcribe",
+        "openai",
+        model=model,
+        parameters=job_parameters,
+        output_paths=final_paths,
+        output_artifacts=final_names,
+        resume=compatible_resume,
+    )
+    if not should_run:
+        return _load_raw(store.path("transcript.json"))
+
+    if client is None:
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            store.fail_job("transcribe", "openai", "OPENAI_API_KEY is not set.", retryable=False)
+            raise RuntimeError("OPENAI_API_KEY is required for OpenAI transcription.")
+        if api_key.startswith("op://"):
+            store.fail_job(
+                "transcribe",
+                "openai",
+                "OPENAI_API_KEY contains an unresolved op:// reference.",
+                retryable=False,
+            )
+            raise RuntimeError("Resolve the op:// key with `op run` before starting Murmur.")
+        try:
+            from openai import OpenAI
+        except ImportError as error:
+            store.fail_job(
+                "transcribe",
+                "openai",
+                "The optional openai package is not installed.",
+                retryable=False,
+            )
+            raise RuntimeError("Install Murmur with the `cloud` extra.") from error
+        client = OpenAI(api_key=api_key)
+
+    responses = []
+    raw_index = []
+    provenance = {
+        "provider": "openai",
+        "model": model,
+        "parameters": {
+            "language": language,
+            "prompt": prompt,
+            "chunk_seconds": chunk_seconds,
+            "overlap_seconds": overlap_seconds,
+            "stream_index": stream_index,
+        },
+    }
+    try:
+        for chunk in chunks:
+            chunk_path = store.path(f"chunks/{chunk.unit_id}.wav")
+            chunk_artifact = f"{chunk.unit_id}_audio"
+            if not (compatible_resume and store.artifact_valid(chunk_artifact)):
+                _extract_chunk(recording_path, chunk_path, chunk, stream_index)
+                store.register_artifact(
+                    chunk_artifact,
+                    chunk_path,
+                    kind="transcription_chunk",
+                    provenance={
+                        "start": chunk.start,
+                        "duration": chunk.duration,
+                        "sample_rate": 16000,
+                        "channels": 1,
+                        "stream_index": stream_index,
+                    },
+                )
+            if chunk_path.stat().st_size > SAFE_UPLOAD_BYTES:
+                raise RuntimeError(
+                    f"{chunk_path.name} is too close to the 25 MB upload limit; "
+                    "reduce --chunk-seconds."
+                )
+
+            raw_name = f"{chunk.unit_id}_raw"
+            raw_path = store.path(f"raw-responses/{chunk.unit_id}.json")
+            _, should_submit = store.begin_unit(
+                "transcribe",
+                "openai",
+                chunk.unit_id,
+                parameters={
+                    "start": chunk.start,
+                    "duration": chunk.duration,
+                    "audio_artifact": chunk_artifact,
+                },
+                output_artifacts=[raw_name],
+                resume=compatible_resume,
+            )
+            if not should_submit:
+                try:
+                    response = _load_raw(raw_path)
+                except (OSError, ValueError, json.JSONDecodeError) as error:
+                    store.fail_unit("transcribe", "openai", chunk.unit_id, error)
+                    _, should_submit = store.begin_unit(
+                        "transcribe",
+                        "openai",
+                        chunk.unit_id,
+                        output_artifacts=[raw_name],
+                    )
+            if should_submit:
+                try:
+                    response = _submit_chunk(
+                        client,
+                        chunk_path,
+                        model=model,
+                        language=language,
+                        prompt=prompt,
+                    )
+                except Exception as error:
+                    error_path = store.write_json(
+                        f"raw-responses/{chunk.unit_id}.error.json",
+                        _error_payload(error),
+                        sanitize=True,
+                    )
+                    store.register_artifact(
+                        f"{chunk.unit_id}_error",
+                        error_path,
+                        kind="provider_error",
+                        provenance=provenance,
+                    )
+                    store.fail_unit(
+                        "transcribe",
+                        "openai",
+                        chunk.unit_id,
+                        error,
+                        retryable=_retryable_error(error),
+                    )
+                    raise TranscriptionProviderError(
+                        f"OpenAI failed for {chunk.unit_id}; inspect {error_path}",
+                        retryable=_retryable_error(error),
+                    ) from error
+                raw_path = store.write_json(f"raw-responses/{chunk.unit_id}.json", response)
+                store.register_artifact(
+                    raw_name,
+                    raw_path,
+                    kind="raw_provider_response",
+                    provenance=provenance,
+                )
+                store.complete_unit("transcribe", "openai", chunk.unit_id)
+            responses.append((chunk, response))
+            raw_index.append(
+                {
+                    "chunk_index": chunk.index,
+                    "start": chunk.start,
+                    "duration": chunk.duration,
+                    "audio_artifact": chunk_artifact,
+                    "response_artifact": raw_name,
+                }
+            )
+
+        segments = _merge_responses(responses)
+        canonical = {
+            "schema_version": 1,
+            "recording_id": store.recording_id,
+            "source": str(recording_path),
+            "source_fingerprint": manifest["source_fingerprint"],
+            "provider": "openai",
+            "model": model,
+            "language": language,
+            "duration_secs": duration,
+            "segments": segments,
+            "text": " ".join(segment["text"] for segment in segments),
+        }
+        raw_manifest_path = store.write_json(
+            "transcript.raw.json",
+            {"provider": "openai", "model": model, "chunks": raw_index},
+        )
+        transcript_path = store.write_json("transcript.json", canonical)
+        markdown_path = store.write_text("transcript.md", _render_markdown(segments))
+        srt_path = store.write_text("transcript.srt", _render_srt(segments))
+        for name, path, kind in (
+            ("transcript_raw", raw_manifest_path, "raw_response_index"),
+            ("transcript_json", transcript_path, "normalized_transcript"),
+            ("transcript_markdown", markdown_path, "transcript_markdown"),
+            ("transcript_srt", srt_path, "subtitles"),
+        ):
+            store.register_artifact(name, path, kind=kind, provenance=provenance)
+        store.complete_job("transcribe", "openai")
+        return canonical
+    except Exception as error:
+        store.fail_job("transcribe", "openai", error, retryable=_retryable_error(error))
+        raise

--- a/src/murmur/plugins/transcribe.py
+++ b/src/murmur/plugins/transcribe.py
@@ -1,4 +1,4 @@
-"""Murmur plugin: transcription via faster-whisper."""
+"""Murmur transcription plugin with local and OpenAI providers."""
 
 from __future__ import annotations
 
@@ -7,6 +7,14 @@ from rich.console import Console
 
 from murmur import hooks
 from murmur.artifacts import ArtifactStore
+from murmur.cloud_transcribe import (
+    DEFAULT_CHUNK_SECONDS,
+    DEFAULT_OVERLAP_SECONDS,
+    transcribe_openai,
+)
+from murmur.cloud_transcribe import (
+    DEFAULT_MODEL as DEFAULT_OPENAI_MODEL,
+)
 from murmur.config import get_section
 
 console = Console()
@@ -130,28 +138,101 @@ def register(cli: click.Group) -> None:
 
     @cli.command()
     @click.argument("file", type=click.Path(exists=True))
-    @click.option("-m", "--model", default=None, help="Whisper model size (default: base).")
+    @click.option(
+        "--provider",
+        type=click.Choice(["local", "openai"]),
+        default=None,
+        help="Transcription provider (default: local).",
+    )
+    @click.option("-m", "--model", default=None, help="Provider model name.")
     @click.option("-l", "--language", default=None, help="Language code (default: en).")
-    def transcribe(file: str, model: str | None, language: str | None):
-        """Transcribe an audio file using faster-whisper."""
-        if not _check_dep():
-            raise SystemExit(1)
-
+    @click.option(
+        "--resume/--restart",
+        default=True,
+        help="Resume valid completed chunks or submit every chunk again.",
+    )
+    @click.option(
+        "--chunk-seconds",
+        type=click.FloatRange(min=1.0),
+        default=DEFAULT_CHUNK_SECONDS,
+        show_default=True,
+    )
+    @click.option(
+        "--overlap-seconds",
+        type=click.FloatRange(min=0.0),
+        default=DEFAULT_OVERLAP_SECONDS,
+        show_default=True,
+    )
+    @click.option("--prompt", default=None, help="Optional vocabulary/context prompt.")
+    def transcribe(
+        file: str,
+        provider: str | None,
+        model: str | None,
+        language: str | None,
+        resume: bool,
+        chunk_seconds: float,
+        overlap_seconds: float,
+        prompt: str | None,
+    ):
+        """Transcribe audio locally or with resumable OpenAI cloud processing."""
         cfg = get_section("transcribe")
-        model_size = model or cfg.get("model", "base")
+        provider_name = provider or cfg.get("provider", "local")
         lang = language or cfg.get("language", "en")
-        _transcribe_file(file, model_size, lang)
+        if provider_name == "local":
+            if not _check_dep():
+                raise SystemExit(1)
+            model_size = model or cfg.get("model", "base")
+            _transcribe_file(file, model_size, lang)
+            return
+
+        model_name = model or cfg.get("openai_model", DEFAULT_OPENAI_MODEL)
+        try:
+            result = transcribe_openai(
+                file,
+                model=model_name,
+                language=lang,
+                prompt=prompt,
+                chunk_seconds=chunk_seconds,
+                overlap_seconds=overlap_seconds,
+                resume=resume,
+            )
+        except (RuntimeError, ValueError) as error:
+            raise click.ClickException(str(error)) from error
+        transcript_path = ArtifactStore(file).path("transcript.md")
+        hooks.emit(
+            "transcription_complete",
+            audio_path=str(file),
+            transcript_path=str(transcript_path),
+        )
+        console.print(
+            f"[bold green]Transcript saved:[/bold green] {transcript_path} "
+            f"({len(result['segments'])} segments)"
+        )
 
     # Auto-transcribe on recording_saved if configured
     cfg = get_section("transcribe")
     if cfg.get("auto"):
 
         def _auto_transcribe(output_path: str, **kwargs):
-            if not _check_dep():
-                return
-            model_size = cfg.get("model", "base")
             lang = cfg.get("language", "en")
             console.print(f"\n[bold]Auto-transcribing[/bold] {output_path}")
-            _transcribe_file(output_path, model_size, lang)
+            if cfg.get("provider", "local") == "openai":
+                transcribe_openai(
+                    output_path,
+                    model=cfg.get("openai_model", DEFAULT_OPENAI_MODEL),
+                    language=lang,
+                    chunk_seconds=cfg.get("chunk_seconds", DEFAULT_CHUNK_SECONDS),
+                    overlap_seconds=cfg.get("overlap_seconds", DEFAULT_OVERLAP_SECONDS),
+                )
+                transcript_path = ArtifactStore(output_path).path("transcript.md")
+                hooks.emit(
+                    "transcription_complete",
+                    audio_path=output_path,
+                    transcript_path=str(transcript_path),
+                )
+                return
+            if not _check_dep():
+                return
+            _transcribe_file(output_path, cfg.get("model", "base"), lang)
 
         hooks.on("recording_saved", _auto_transcribe)

--- a/tests/test_cloud_transcribe.py
+++ b/tests/test_cloud_transcribe.py
@@ -1,0 +1,322 @@
+"""Tests for resumable OpenAI cloud transcription."""
+
+import json
+import shutil
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from murmur.artifacts import ArtifactStore
+from murmur.cloud_transcribe import (
+    Chunk,
+    TranscriptionProviderError,
+    _dedupe_boundary,
+    _extract_chunk,
+    _merge_responses,
+    _select_audio_stream,
+    _submit_chunk,
+    plan_chunks,
+    transcribe_openai,
+)
+
+
+class FakeTranscriptions:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = 0
+
+    def create(self, **kwargs):
+        self.calls += 1
+        response = next(self.responses)
+        if isinstance(response, Exception):
+            raise response
+        return SimpleNamespace(model_dump=lambda mode="json": response)
+
+
+def _client(responses):
+    transcriptions = FakeTranscriptions(responses)
+    return SimpleNamespace(
+        audio=SimpleNamespace(transcriptions=transcriptions), calls=transcriptions
+    )
+
+
+def _recording(tmp_path, content=b"original recording"):
+    recording = tmp_path / "meeting.mka"
+    recording.write_bytes(content)
+    return recording
+
+
+def _fake_extract(recording, output, chunk, stream_index):
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(f"wav:{chunk.index}:{stream_index}".encode())
+
+
+def test_plan_chunks_covers_long_audio_with_overlap():
+    chunks = plan_chunks(3601, chunk_seconds=600, overlap_seconds=2)
+
+    assert chunks[0] == Chunk(index=0, start=0.0, duration=600)
+    assert chunks[1] == Chunk(index=1, start=598.0, duration=600)
+    assert chunks[-1].end == 3601
+    assert all(chunk.duration <= 600 for chunk in chunks)
+
+
+@pytest.mark.parametrize(
+    ("chunk_seconds", "overlap_seconds"),
+    [(0, 0), (10, -1), (10, 10), (10, 11)],
+)
+def test_plan_chunks_rejects_invalid_boundaries(chunk_seconds, overlap_seconds):
+    with pytest.raises(ValueError, match="Chunk duration"):
+        plan_chunks(60, chunk_seconds, overlap_seconds)
+
+
+def test_select_audio_stream_prefers_mixed_then_default():
+    manifest = {
+        "media": {
+            "streams": [
+                {"index": 1, "codec_type": "audio", "default": True},
+                {"index": 2, "codec_type": "audio", "source_role": "mixed"},
+            ]
+        }
+    }
+    assert _select_audio_stream(manifest) == 2
+    manifest["media"]["streams"][1].pop("source_role")
+    assert _select_audio_stream(manifest) == 1
+
+
+def test_boundary_dedup_and_artifact_filtering():
+    assert (
+        _dedupe_boundary("we discussed the launch plan", "the launch plan and owners")
+        == "and owners"
+    )
+    segments = _merge_responses(
+        [
+            (Chunk(0, 0, 10), {"text": "we discussed the launch plan"}),
+            (Chunk(1, 8, 10), {"text": "the launch plan and owners"}),
+            (Chunk(2, 16, 2), {"text": "[Music]"}),
+        ]
+    )
+    assert [segment["text"] for segment in segments] == [
+        "we discussed the launch plan",
+        "and owners",
+    ]
+    assert segments[1]["start"] == 10
+    assert [segment["id"] for segment in segments] == [
+        "segment-000001",
+        "segment-000002",
+    ]
+
+
+def test_openai_pipeline_writes_outputs_and_resumes_without_rebilling(tmp_path):
+    recording = _recording(tmp_path)
+    client = _client(
+        [
+            {"text": "alpha boundary words repeat"},
+            {"text": "boundary words repeat next section"},
+            {"text": "[Silence]"},
+        ]
+    )
+
+    with (
+        patch("murmur.cloud_transcribe._media_duration", return_value=1201),
+        patch("murmur.cloud_transcribe._extract_chunk", side_effect=_fake_extract),
+    ):
+        first = transcribe_openai(recording, client=client)
+        second = transcribe_openai(recording, client=client)
+
+    store = ArtifactStore(recording)
+    assert first == second
+    assert client.calls.calls == 3
+    assert [segment["text"] for segment in first["segments"]] == [
+        "alpha boundary words repeat",
+        "next section",
+    ]
+    assert store.path("transcript.raw.json").exists()
+    assert json.loads(store.path("transcript.json").read_text()) == first
+    assert store.path("transcript.md").read_text().startswith("# Transcript\n")
+    assert "00:00:00,000 --> 00:10:00,000" in store.path("transcript.srt").read_text()
+    assert len(list(store.path("raw-responses").glob("chunk-*.json"))) == 3
+    assert store.jobs()["jobs"]["transcribe:openai"]["status"] == "complete"
+    assert recording.read_bytes() == b"original recording"
+
+
+def test_interrupted_pipeline_resumes_only_incomplete_chunks(tmp_path):
+    recording = _recording(tmp_path)
+    failing = RuntimeError("temporary provider failure")
+    first_client = _client([{"text": "first chunk"}, failing])
+
+    with (
+        patch("murmur.cloud_transcribe._media_duration", return_value=900),
+        patch("murmur.cloud_transcribe._extract_chunk", side_effect=_fake_extract),
+        pytest.raises(TranscriptionProviderError),
+    ):
+        transcribe_openai(recording, client=first_client)
+
+    store = ArtifactStore(recording)
+    job = store.jobs()["jobs"]["transcribe:openai"]
+    assert job["status"] == "failed"
+    assert job["units"]["chunk-0000"]["status"] == "complete"
+    assert job["units"]["chunk-0001"]["status"] == "failed"
+    error_path = store.path("raw-responses/chunk-0001.error.json")
+    assert error_path.exists()
+    assert json.loads(error_path.read_text())["retryable"] is True
+
+    resumed_client = _client([{"text": "second chunk"}])
+    with (
+        patch("murmur.cloud_transcribe._media_duration", return_value=900),
+        patch("murmur.cloud_transcribe._extract_chunk", side_effect=_fake_extract),
+    ):
+        result = transcribe_openai(recording, client=resumed_client)
+
+    assert resumed_client.calls.calls == 1
+    assert result["text"] == "first chunk second chunk"
+    assert store.jobs()["jobs"]["transcribe:openai"]["attempt_count"] == 2
+
+
+def test_corrupt_completed_raw_response_is_resubmitted(tmp_path):
+    recording = _recording(tmp_path)
+    initial_client = _client([{"text": "one"}, {"text": "two"}])
+    with (
+        patch("murmur.cloud_transcribe._media_duration", return_value=900),
+        patch("murmur.cloud_transcribe._extract_chunk", side_effect=_fake_extract),
+    ):
+        transcribe_openai(recording, client=initial_client)
+
+    store = ArtifactStore(recording)
+    store.path("transcript.json").write_text("corrupt final")
+    store.path("raw-responses/chunk-0001.json").write_text("corrupt raw")
+    repair_client = _client([{"text": "two repaired"}])
+    with (
+        patch("murmur.cloud_transcribe._media_duration", return_value=900),
+        patch("murmur.cloud_transcribe._extract_chunk", side_effect=_fake_extract),
+    ):
+        repaired = transcribe_openai(recording, client=repair_client)
+
+    assert repair_client.calls.calls == 1
+    assert repaired["text"] == "one two repaired"
+
+
+def test_changed_model_invalidates_completed_resume(tmp_path):
+    recording = _recording(tmp_path)
+    first_client = _client([{"text": "old model"}])
+    with (
+        patch("murmur.cloud_transcribe._media_duration", return_value=30),
+        patch("murmur.cloud_transcribe._extract_chunk", side_effect=_fake_extract),
+    ):
+        transcribe_openai(recording, model="first-model", client=first_client)
+
+    second_client = _client([{"text": "new model"}])
+    with (
+        patch("murmur.cloud_transcribe._media_duration", return_value=30),
+        patch("murmur.cloud_transcribe._extract_chunk", side_effect=_fake_extract),
+    ):
+        result = transcribe_openai(recording, model="second-model", client=second_client)
+
+    assert second_client.calls.calls == 1
+    assert result["model"] == "second-model"
+    assert result["text"] == "new model"
+
+
+def test_provider_error_is_sanitized_and_marked_non_retryable(tmp_path):
+    recording = _recording(tmp_path)
+
+    class BadRequest(Exception):
+        status_code = 400
+        request_id = "request-123"
+
+    client = _client([BadRequest("bad key sk-secretvalue123")])
+    with (
+        patch("murmur.cloud_transcribe._media_duration", return_value=30),
+        patch("murmur.cloud_transcribe._extract_chunk", side_effect=_fake_extract),
+        pytest.raises(TranscriptionProviderError),
+    ):
+        transcribe_openai(recording, client=client)
+
+    error_path = ArtifactStore(recording).path("raw-responses/chunk-0000.error.json")
+    persisted = error_path.read_text()
+    assert "secretvalue" not in persisted
+    assert json.loads(persisted)["retryable"] is False
+    job = ArtifactStore(recording).jobs()["jobs"]["transcribe:openai"]
+    assert job["retryable"] is False
+
+
+def test_submit_chunk_uses_openai_multipart_contract(tmp_path):
+    import httpx
+    from openai import OpenAI
+
+    chunk = tmp_path / "chunk.wav"
+    chunk.write_bytes(b"RIFF fake wav")
+
+    def handler(request):
+        assert request.url.path == "/v1/audio/transcriptions"
+        assert request.headers["authorization"] == "Bearer test-api-key"
+        body = request.read()
+        assert b'name="model"' in body
+        assert b"gpt-4o-transcribe" in body
+        assert b'name="response_format"' in body
+        assert b"json" in body
+        assert b'name="language"' in body
+        assert b"en" in body
+        assert b'name="prompt"' in body
+        assert b"Sujata Abby Rohan Jatan" in body
+        assert b'name="file"; filename="chunk.wav"' in body
+        return httpx.Response(200, json={"text": "hello"})
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = OpenAI(
+        api_key="test-api-key", base_url="https://api.openai.test/v1", http_client=http_client
+    )
+
+    result = _submit_chunk(
+        client,
+        chunk,
+        model="gpt-4o-transcribe",
+        language="en",
+        prompt="Sujata Abby Rohan Jatan",
+    )
+
+    assert result["text"] == "hello"
+
+
+@pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="FFmpeg integration tools are unavailable",
+)
+def test_extract_chunk_produces_16khz_mono_lossless_wav(tmp_path):
+    recording = tmp_path / "source.wav"
+    subprocess.run(  # noqa: S603
+        [
+            str(shutil.which("ffmpeg")),
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:sample_rate=48000:duration=2",
+            str(recording),
+        ],
+        check=True,
+    )
+    output = tmp_path / "chunk.wav"
+
+    _extract_chunk(recording, output, Chunk(0, 0.5, 1.0), stream_index=0)
+
+    probe = subprocess.run(  # noqa: S603
+        [
+            str(shutil.which("ffprobe")),
+            "-v",
+            "error",
+            "-show_entries",
+            "stream=codec_name,sample_rate,channels",
+            "-of",
+            "json",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    stream = json.loads(probe.stdout)["streams"][0]
+    assert stream == {"codec_name": "pcm_s16le", "sample_rate": "16000", "channels": 1}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -27,6 +27,8 @@ def test_transcribe_registers_command():
     grp = _make_group()
     transcribe.register(grp)
     assert "transcribe" in [c for c in grp.commands]
+    param_names = [parameter.name for parameter in grp.commands["transcribe"].params]
+    assert {"provider", "resume", "chunk_seconds", "overlap_seconds"} <= set(param_names)
 
 
 def test_summarize_registers_command():
@@ -147,6 +149,46 @@ def test_local_transcription_persists_artifacts_and_resumes(tmp_path):
     jobs = json.loads((artifact_dir / "jobs.json").read_text())["jobs"]
     assert jobs["transcribe:faster-whisper"]["status"] == "complete"
     assert FakeWhisperModel.calls == 1
+
+
+def test_transcribe_openai_provider_dispatches_cloud_pipeline(tmp_path):
+    audio = tmp_path / "meeting.flac"
+    audio.write_bytes(b"audio")
+    grp = _make_group()
+    transcribe.register(grp)
+
+    with (
+        patch.object(transcribe, "transcribe_openai", return_value={"segments": []}) as cloud,
+        patch.object(transcribe.hooks, "emit"),
+    ):
+        result = runner.invoke(
+            grp,
+            [
+                "transcribe",
+                str(audio),
+                "--provider",
+                "openai",
+                "--model",
+                "gpt-4o-transcribe",
+                "--chunk-seconds",
+                "300",
+                "--overlap-seconds",
+                "1",
+                "--prompt",
+                "project glossary",
+            ],
+        )
+
+    assert result.exit_code == 0
+    cloud.assert_called_once_with(
+        str(audio),
+        model="gpt-4o-transcribe",
+        language="en",
+        prompt="project glossary",
+        chunk_seconds=300.0,
+        overlap_seconds=1.0,
+        resume=True,
+    )
 
 
 def test_diarization_persists_canonical_outputs(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -1407,6 +1407,7 @@ all = [
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
     { name = "litellm" },
+    { name = "openai" },
     { name = "pyannote-audio" },
     { name = "tasklib" },
     { name = "textual" },
@@ -1417,6 +1418,9 @@ calendar = [
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
 ]
+cloud = [
+    { name = "openai" },
+]
 dev = [
     { name = "bandit" },
     { name = "dspy" },
@@ -1426,6 +1430,7 @@ dev = [
     { name = "google-auth-oauthlib" },
     { name = "litellm" },
     { name = "mypy" },
+    { name = "openai" },
     { name = "pre-commit" },
     { name = "pyannote-audio" },
     { name = "pytest" },
@@ -1467,12 +1472,14 @@ requires-dist = [
     { name = "murmur", extras = ["ai"], marker = "extra == 'tasks'" },
     { name = "murmur", extras = ["all"], marker = "extra == 'dev'" },
     { name = "murmur", extras = ["calendar"], marker = "extra == 'all'" },
+    { name = "murmur", extras = ["cloud"], marker = "extra == 'all'" },
     { name = "murmur", extras = ["diarize"], marker = "extra == 'all'" },
     { name = "murmur", extras = ["tasks"], marker = "extra == 'all'" },
     { name = "murmur", extras = ["tasks-tw"], marker = "extra == 'all'" },
     { name = "murmur", extras = ["transcribe"], marker = "extra == 'all'" },
     { name = "murmur", extras = ["tui"], marker = "extra == 'all'" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
+    { name = "openai", marker = "extra == 'cloud'", specifier = ">=1.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyannote-audio", marker = "extra == 'diarize'", specifier = ">=3.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -1483,7 +1490,7 @@ requires-dist = [
     { name = "textual", marker = "extra == 'tui'", specifier = ">=8.1.1" },
     { name = "torch", marker = "extra == 'diarize'" },
 ]
-provides-extras = ["tui", "ai", "transcribe", "diarize", "calendar", "tasks", "tasks-tw", "all", "dev"]
+provides-extras = ["tui", "ai", "transcribe", "cloud", "diarize", "calendar", "tasks", "tasks-tw", "all", "dev"]
 
 [[package]]
 name = "mypy"


### PR DESCRIPTION
## Summary
- add sequential OpenAI transcription with metadata-based stream selection and lossless 16 kHz mono WAV chunking below the 25 MB upload limit
- persist every raw response plus canonical JSON, Markdown, and SRT outputs with absolute timestamps, overlap deduplication, and artifact filtering
- resume checksum-valid chunks without repeat billing, invalidate incompatible model/config resumes, and persist sanitized retryable provider errors
- keep local faster-whisper as a separate provider and document 1Password `op run` credential injection

## Verification
- `uvx --no-config ruff check .`
- `uvx --no-config ruff format --check .`
- `uv --no-config run --extra cloud --with pytest --with pytest-cov pytest` (95 passed)
- OpenAI SDK multipart request exercised through `httpx.MockTransport`
- FFmpeg integration verifies PCM 16-bit, 16 kHz, mono WAV output

Closes #22
