### PR TITLE
feat: add speaker-aware channel diarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ auto = true          # auto-transcribe after recording
 provider = "local"   # local or openai
 model = "base"       # whisper model size
 openai_model = "gpt-4o-transcribe"
+diarize = false
+diarize_model = "gpt-4o-transcribe-diarize"
+speaker_profile = "default"
 language = "en"
 chunk_seconds = 600
 overlap_seconds = 2
@@ -198,6 +201,43 @@ Resume is enabled by default; use `--restart` only when you intentionally want
 to submit every chunk again. The source recording is opened read-only and is
 never rewritten.
 
+### Speaker profiles and channel-aware diarization
+
+Speaker names are never assigned from anonymous cluster order. Add confirmed
+2-10 second clips to a private profile, classifying people by the side of the
+call where their voice is captured:
+
+```bash
+murmur speakers add Rohan --side local --clip rohan-reference.wav
+murmur speakers add Jatan --side local --clip jatan-reference.wav
+murmur speakers add Sujata --side remote --clip sujata-reference.wav
+murmur speakers add Abby --side remote --clip abby-reference.wav
+
+OPENAI_API_KEY='op://Personal/OPENAI_API_KEY/credential' \
+  op run -- murmur transcribe meeting.mka --diarize --speaker-profile default
+```
+
+On multitrack recordings, Murmur submits the microphone and call-output streams
+independently with only the references relevant to that side, then merges their
+absolute timelines while preserving simultaneous speech. Unknown identities
+remain explicit, such as `unknown:remote:chunk-0002:B`; they are not silently
+guessed across chunk label resets.
+
+Reference clips are normalized to private 16 kHz mono WAV files under
+`~/.config/murmur/speaker-profiles` and are converted to data URLs only in
+memory for an API request. Review and manage them with:
+
+```bash
+murmur speakers list
+murmur speakers identify meeting.mka
+murmur speakers export default --output default-speakers.zip
+murmur speakers delete default --speaker Rohan
+murmur speakers delete default
+```
+
+`speakers identify` exports candidate clips for unresolved labels. Adding one
+of those candidates to a profile is the explicit human confirmation step.
+
 ## Plugins
 
 | Plugin | Command | What it does | Install |
@@ -233,6 +273,6 @@ the private process in [SECURITY.md](SECURITY.md).
 ## Roadmap
 
 - [x] Automatic transcription (local Whisper / OpenAI)
-- [ ] Speaker diarization
+- [x] Speaker diarization with confirmed identity profiles
 - [x] Auto-detect meeting apps and start recording
 - [ ] Web UI for browsing/searching recordings

--- a/src/murmur/cloud_diarize.py
+++ b/src/murmur/cloud_diarize.py
@@ -1,0 +1,443 @@
+"""Channel-aware OpenAI transcription with anchored speaker identities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from murmur.artifacts import ArtifactStore
+from murmur.cloud_transcribe import (
+    DEFAULT_CHUNK_SECONDS,
+    DEFAULT_OVERLAP_SECONDS,
+    SAFE_UPLOAD_BYTES,
+    TranscriptionProviderError,
+    _artifact_segment,
+    _clock,
+    _dedupe_boundary,
+    _error_payload,
+    _extract_chunk,
+    _load_raw,
+    _media_duration,
+    _response_payload,
+    _retryable_error,
+    plan_chunks,
+)
+from murmur.speaker_profiles import load_profile, reference_payload
+
+DEFAULT_DIARIZE_MODEL = "gpt-4o-transcribe-diarize"
+
+
+@dataclass(frozen=True)
+class Track:
+    side: str
+    stream_index: int
+
+
+def _select_tracks(manifest: dict[str, Any]) -> list[Track]:
+    streams = manifest.get("media", {}).get("streams", [])
+    by_role = {
+        stream.get("source_role"): int(stream.get("index", 0))
+        for stream in streams
+        if stream.get("codec_type", "audio") == "audio"
+    }
+    if "microphone" in by_role and "call_output" in by_role:
+        return [Track("local", by_role["microphone"]), Track("remote", by_role["call_output"])]
+    if "microphone" in by_role:
+        return [Track("local", by_role["microphone"])]
+    if "call_output" in by_role:
+        return [Track("remote", by_role["call_output"])]
+    mixed = next(
+        (
+            int(stream.get("index", 0))
+            for stream in streams
+            if stream.get("source_role") == "mixed" or stream.get("title") == "Mixed call"
+        ),
+        int(streams[0].get("index", 0)) if streams else 0,
+    )
+    return [Track("unknown", mixed)]
+
+
+def _submit_diarized_chunk(
+    client: Any,
+    chunk_path: Path,
+    *,
+    model: str,
+    language: str | None,
+    known_names: list[str],
+    known_references: list[str],
+) -> dict[str, Any]:
+    request: dict[str, Any] = {
+        "model": model,
+        "response_format": "diarized_json",
+        "chunking_strategy": "auto",
+    }
+    if language:
+        request["language"] = language
+    if known_names:
+        request["known_speaker_names"] = known_names
+        request["known_speaker_references"] = known_references
+    with chunk_path.open("rb") as audio:
+        response = client.audio.transcriptions.create(file=audio, **request)
+    return _response_payload(response)
+
+
+def _normalize_segments(
+    payload: dict[str, Any],
+    *,
+    side: str,
+    stream_index: int,
+    chunk_index: int,
+    chunk_start: float,
+    chunk_duration: float,
+    known_names: set[str],
+) -> list[dict[str, Any]]:
+    normalized = []
+    raw_segments = payload.get("segments", [])
+    if not isinstance(raw_segments, list):
+        return normalized
+    for segment_index, segment in enumerate(raw_segments):
+        text = str(segment.get("text", "")).strip()
+        if _artifact_segment(text):
+            continue
+        local_start = max(0.0, float(segment.get("start", 0.0)))
+        local_end = min(chunk_duration, float(segment.get("end", chunk_duration)))
+        if local_end <= local_start:
+            continue
+        raw_speaker = str(segment.get("speaker") or "speaker")
+        speaker = (
+            raw_speaker
+            if raw_speaker in known_names
+            else f"unknown:{side}:chunk-{chunk_index:04d}:{raw_speaker}"
+        )
+        normalized.append(
+            {
+                "id": f"{side}:chunk-{chunk_index:04d}:{segment_index}",
+                "chunk_index": chunk_index,
+                "side": side,
+                "stream_index": stream_index,
+                "speaker": speaker,
+                "raw_speaker": raw_speaker,
+                "start": round(chunk_start + local_start, 3),
+                "end": round(chunk_start + local_end, 3),
+                "text": text,
+            }
+        )
+    return normalized
+
+
+def _merge_track_segments(chunks: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = []
+    for incoming in chunks:
+        if merged and incoming:
+            first = incoming[0]
+            previous = merged[-1]
+            first["text"] = _dedupe_boundary(previous["text"], first["text"])
+            first["start"] = max(first["start"], previous["end"])
+            if _artifact_segment(first["text"]) or first["end"] <= first["start"]:
+                incoming.pop(0)
+        merged.extend(incoming)
+    return merged
+
+
+def _render_markdown(segments: list[dict[str, Any]]) -> str:
+    lines = ["# Speaker transcript", ""]
+    lines.extend(
+        f"[{_clock(segment['start'])}] **{segment['speaker']}** "
+        f"({segment['side']}): {segment['text']}"
+        for segment in segments
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _render_srt(segments: list[dict[str, Any]]) -> str:
+    blocks = []
+    for index, segment in enumerate(segments, 1):
+        blocks.append(
+            f"{index}\n{_clock(segment['start'], srt=True)} --> "
+            f"{_clock(segment['end'], srt=True)}\n"
+            f"[{segment['speaker']}] {segment['text']}\n"
+        )
+    return "\n".join(blocks)
+
+
+def _profile_digest(profile: dict[str, Any]) -> str:
+    identity = {
+        "name": profile.get("name"),
+        "speakers": [
+            {
+                "id": speaker.get("id"),
+                "display_name": speaker.get("display_name"),
+                "side": speaker.get("side"),
+                "references": [
+                    {
+                        "path": reference.get("path"),
+                        "duration_secs": reference.get("duration_secs"),
+                        "fingerprint": reference.get("fingerprint"),
+                    }
+                    for reference in speaker.get("references", [])
+                ],
+            }
+            for speaker in profile.get("speakers", [])
+        ],
+    }
+    serialized = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def transcribe_openai_diarized(
+    recording: str | Path,
+    *,
+    profile_name: str = "default",
+    model: str = DEFAULT_DIARIZE_MODEL,
+    language: str | None = None,
+    chunk_seconds: float = DEFAULT_CHUNK_SECONDS,
+    overlap_seconds: float = DEFAULT_OVERLAP_SECONDS,
+    resume: bool = True,
+    client: Any | None = None,
+) -> dict[str, Any]:
+    """Diarize independent source tracks and merge them without losing overlap."""
+    recording_path = Path(recording).expanduser().resolve()
+    store = ArtifactStore(recording_path)
+    manifest = store.ensure_manifest()
+    duration = float(
+        manifest.get("media", {}).get("duration_secs") or _media_duration(recording_path)
+    )
+    chunks = plan_chunks(duration, chunk_seconds, overlap_seconds)
+    tracks = _select_tracks(manifest)
+    profile = load_profile(profile_name)
+    profile_digest = _profile_digest(profile)
+    job_parameters = {
+        "profile": profile_name,
+        "profile_sha256": profile_digest,
+        "chunk_seconds": chunk_seconds,
+        "overlap_seconds": overlap_seconds,
+        "tracks": [track.__dict__ for track in tracks],
+        "channel_aware": len(tracks) > 1,
+    }
+    if language is not None:
+        job_parameters["language"] = language
+    artifact_names = [
+        "diarized_transcript_raw",
+        "diarized_transcript_json",
+        "diarized_transcript_markdown",
+        "diarized_transcript_srt",
+    ]
+    output_paths = [
+        store.path("transcript.diarized.raw.json"),
+        store.path("transcript.json"),
+        store.path("transcript.md"),
+        store.path("transcript.srt"),
+    ]
+    previous = store.jobs().get("jobs", {}).get("transcribe:openai-diarize", {})
+    compatible_resume = bool(
+        resume and previous.get("model") == model and previous.get("parameters") == job_parameters
+    )
+    _, should_run = store.begin_job(
+        "transcribe",
+        "openai-diarize",
+        model=model,
+        parameters=job_parameters,
+        output_paths=output_paths,
+        output_artifacts=artifact_names,
+        resume=compatible_resume,
+    )
+    if not should_run:
+        return _load_raw(store.path("transcript.json"))
+
+    if client is None:
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            store.fail_job(
+                "transcribe", "openai-diarize", "OPENAI_API_KEY is not set.", retryable=False
+            )
+            raise RuntimeError("OPENAI_API_KEY is required for OpenAI diarization.")
+        if api_key.startswith("op://"):
+            store.fail_job(
+                "transcribe",
+                "openai-diarize",
+                "OPENAI_API_KEY contains an unresolved op:// reference.",
+                retryable=False,
+            )
+            raise RuntimeError("Resolve the op:// key with `op run` before starting Murmur.")
+        try:
+            from openai import OpenAI
+        except ImportError as error:
+            store.fail_job(
+                "transcribe",
+                "openai-diarize",
+                "The optional openai package is not installed.",
+                retryable=False,
+            )
+            raise RuntimeError("Install Murmur with the `cloud` extra.") from error
+        client = OpenAI(api_key=api_key)
+
+    all_segments: list[dict[str, Any]] = []
+    raw_index = []
+    provenance = {
+        "provider": "openai",
+        "model": model,
+        "profile": profile_name,
+        "profile_sha256": profile_digest,
+    }
+    try:
+        for track in tracks:
+            known_names, known_references = reference_payload(profile_name, track.side)
+            track_chunks: list[list[dict[str, Any]]] = []
+            for chunk in chunks:
+                unit_id = f"{track.side}-{chunk.unit_id}"
+                chunk_path = store.path(f"chunks/diarize/{track.side}/{chunk.unit_id}.wav")
+                chunk_artifact = f"diarize_{unit_id}_audio"
+                if not (compatible_resume and store.artifact_valid(chunk_artifact)):
+                    _extract_chunk(recording_path, chunk_path, chunk, track.stream_index)
+                    store.register_artifact(
+                        chunk_artifact,
+                        chunk_path,
+                        kind="diarization_chunk",
+                        provenance={
+                            "side": track.side,
+                            "stream_index": track.stream_index,
+                            "start": chunk.start,
+                            "duration": chunk.duration,
+                            "sample_rate": 16000,
+                            "channels": 1,
+                        },
+                    )
+                if chunk_path.stat().st_size > SAFE_UPLOAD_BYTES:
+                    raise RuntimeError(
+                        f"{chunk_path.name} is too close to the upload limit; "
+                        "reduce --chunk-seconds."
+                    )
+                raw_name = f"diarize_{unit_id}_raw"
+                raw_path = store.path(f"raw-responses/diarize/{track.side}/{chunk.unit_id}.json")
+                _, should_submit = store.begin_unit(
+                    "transcribe",
+                    "openai-diarize",
+                    unit_id,
+                    parameters={
+                        "side": track.side,
+                        "stream_index": track.stream_index,
+                        "start": chunk.start,
+                        "duration": chunk.duration,
+                        "known_speakers": known_names,
+                    },
+                    output_artifacts=[raw_name],
+                    resume=compatible_resume,
+                )
+                if not should_submit:
+                    try:
+                        response = _load_raw(raw_path)
+                    except (OSError, ValueError, json.JSONDecodeError) as error:
+                        store.fail_unit("transcribe", "openai-diarize", unit_id, error)
+                        _, should_submit = store.begin_unit(
+                            "transcribe",
+                            "openai-diarize",
+                            unit_id,
+                            output_artifacts=[raw_name],
+                        )
+                if should_submit:
+                    try:
+                        response = _submit_diarized_chunk(
+                            client,
+                            chunk_path,
+                            model=model,
+                            language=language,
+                            known_names=known_names,
+                            known_references=known_references,
+                        )
+                    except Exception as error:
+                        error_path = store.write_json(
+                            f"raw-responses/diarize/{track.side}/{chunk.unit_id}.error.json",
+                            _error_payload(error),
+                            sanitize=True,
+                        )
+                        store.register_artifact(
+                            f"diarize_{unit_id}_error",
+                            error_path,
+                            kind="provider_error",
+                            provenance=provenance,
+                        )
+                        store.fail_unit(
+                            "transcribe",
+                            "openai-diarize",
+                            unit_id,
+                            error,
+                            retryable=_retryable_error(error),
+                        )
+                        raise TranscriptionProviderError(
+                            f"OpenAI failed for {unit_id}; inspect {error_path}",
+                            retryable=_retryable_error(error),
+                        ) from error
+                    raw_path = store.write_json(
+                        f"raw-responses/diarize/{track.side}/{chunk.unit_id}.json", response
+                    )
+                    store.register_artifact(
+                        raw_name,
+                        raw_path,
+                        kind="raw_provider_response",
+                        provenance=provenance,
+                    )
+                    store.complete_unit("transcribe", "openai-diarize", unit_id)
+                track_chunks.append(
+                    _normalize_segments(
+                        response,
+                        side=track.side,
+                        stream_index=track.stream_index,
+                        chunk_index=chunk.index,
+                        chunk_start=chunk.start,
+                        chunk_duration=chunk.duration,
+                        known_names=set(known_names),
+                    )
+                )
+                raw_index.append(
+                    {
+                        "side": track.side,
+                        "stream_index": track.stream_index,
+                        "chunk_index": chunk.index,
+                        "start": chunk.start,
+                        "duration": chunk.duration,
+                        "response_artifact": raw_name,
+                    }
+                )
+            all_segments.extend(_merge_track_segments(track_chunks))
+
+        all_segments.sort(key=lambda segment: (segment["start"], segment["end"], segment["side"]))
+        for index, segment in enumerate(all_segments, 1):
+            segment["id"] = f"segment-{index:06d}"
+        canonical = {
+            "schema_version": 1,
+            "recording_id": store.recording_id,
+            "source": str(recording_path),
+            "source_fingerprint": manifest["source_fingerprint"],
+            "provider": "openai",
+            "model": model,
+            "speaker_profile": profile_name,
+            "speaker_profile_sha256": profile_digest,
+            "channel_aware": len(tracks) > 1,
+            "language": language,
+            "duration_secs": duration,
+            "segments": all_segments,
+            "text": " ".join(segment["text"] for segment in all_segments),
+        }
+        raw_manifest = store.write_json(
+            "transcript.diarized.raw.json",
+            {"provider": "openai", "model": model, "profile": profile_name, "chunks": raw_index},
+        )
+        transcript = store.write_json("transcript.json", canonical)
+        markdown = store.write_text("transcript.md", _render_markdown(all_segments))
+        subtitles = store.write_text("transcript.srt", _render_srt(all_segments))
+        for name, path, kind in (
+            ("diarized_transcript_raw", raw_manifest, "raw_response_index"),
+            ("diarized_transcript_json", transcript, "normalized_speaker_transcript"),
+            ("diarized_transcript_markdown", markdown, "speaker_transcript_markdown"),
+            ("diarized_transcript_srt", subtitles, "speaker_subtitles"),
+        ):
+            store.register_artifact(name, path, kind=kind, provenance=provenance)
+        store.complete_job("transcribe", "openai-diarize")
+        return canonical
+    except Exception as error:
+        store.fail_job("transcribe", "openai-diarize", error, retryable=_retryable_error(error))
+        raise

--- a/src/murmur/plugins/diarize.py
+++ b/src/murmur/plugins/diarize.py
@@ -9,6 +9,14 @@ from rich.console import Console
 
 from murmur.artifacts import ArtifactStore
 from murmur.config import get_section
+from murmur.speaker_profiles import (
+    SIDES,
+    add_speaker,
+    delete_profile,
+    export_profile,
+    export_unknown_candidates,
+    list_profiles,
+)
 
 console = Console()
 
@@ -26,24 +34,21 @@ def _check_dep():
         return False
 
 
-def _diarize_file(
-    file: str, token: str, speaker_names: dict[str, str] | None = None
-) -> tuple[Path, Path, set[str]]:
+def _diarize_file(file: str, token: str) -> tuple[Path, Path, set[str]]:
     """Run pyannote and persist canonical diarization artifacts."""
     from io import StringIO
 
     from pyannote.audio import Pipeline
 
-    speaker_names = speaker_names or {}
     audio_path = Path(file)
     store = ArtifactStore(audio_path)
     rttm_path = store.path("speakers/diarization.rttm")
     timeline_path = store.path("speakers/diarization.txt")
     _, should_run = store.begin_job(
         "diarize",
-        "pyannote",
+        "pyannote-clusters",
         model="pyannote/speaker-diarization-3.1",
-        parameters={"speaker_names": list(speaker_names.values())},
+        parameters={"identity_mapping": "unresolved"},
         output_paths=[rttm_path, timeline_path],
         output_artifacts=["diarization_rttm", "diarization_timeline"],
     )
@@ -63,15 +68,14 @@ def _diarize_file(
         timeline = []
         for turn, _, speaker in diarization.itertracks(yield_label=True):
             seen_speakers.add(speaker)
-            label = speaker_names.get(speaker, speaker)
-            line = f"[{turn.start:.1f}s -> {turn.end:.1f}s] {label}"
+            line = f"[{turn.start:.1f}s -> {turn.end:.1f}s] {speaker}"
             timeline.append(line)
             console.print(f"  [dim]{line}[/dim]")
         timeline_path = store.write_text("speakers/diarization.txt", "\n".join(timeline) + "\n")
         provenance = {
             "provider": "pyannote",
             "model": "pyannote/speaker-diarization-3.1",
-            "parameters": {"speaker_names": list(speaker_names.values())},
+            "parameters": {"identity_mapping": "unresolved"},
         }
         store.register_artifact(
             "diarization_rttm", rttm_path, kind="speaker_timeline", provenance=provenance
@@ -82,15 +86,110 @@ def _diarize_file(
             kind="speaker_timeline_text",
             provenance=provenance,
         )
-        store.complete_job("diarize", "pyannote")
+        store.complete_job("diarize", "pyannote-clusters")
         return rttm_path, timeline_path, seen_speakers
     except Exception as error:
-        store.fail_job("diarize", "pyannote", error)
+        store.fail_job("diarize", "pyannote-clusters", error)
         raise
 
 
 def register(cli: click.Group) -> None:
     """Register the diarize command."""
+
+    @cli.group()
+    def speakers():
+        """Manage private confirmed speaker profiles."""
+
+    @speakers.command("add")
+    @click.argument("display_name")
+    @click.option("--side", type=click.Choice(SIDES), required=True)
+    @click.option("--clip", type=click.Path(exists=True), required=True)
+    @click.option("--profile", default="default", show_default=True)
+    @click.option("--source-recording", type=click.Path(exists=True), default=None)
+    @click.option("--source-start", type=click.FloatRange(min=0), default=None)
+    @click.option("--source-end", type=click.FloatRange(min=0), default=None)
+    def speakers_add(
+        display_name: str,
+        side: str,
+        clip: str,
+        profile: str,
+        source_recording: str | None,
+        source_start: float | None,
+        source_end: float | None,
+    ):
+        """Add a confirmed 2-10 second reference clip."""
+        try:
+            speaker = add_speaker(
+                display_name,
+                side=side,
+                clip=clip,
+                profile=profile,
+                source_recording=source_recording,
+                source_start=source_start,
+                source_end=source_end,
+            )
+        except (FileNotFoundError, RuntimeError, ValueError) as error:
+            raise click.ClickException(str(error)) from error
+        console.print(
+            f"[green]Saved {speaker['display_name']} ({speaker['side']}) in profile "
+            f"{profile}.[/green]"
+        )
+
+    @speakers.command("list")
+    def speakers_list():
+        """List profiles and locally stored voice references."""
+        profiles = list_profiles()
+        if not profiles:
+            console.print("[yellow]No speaker profiles found.[/yellow]")
+            return
+        for profile in profiles:
+            console.print(f"[bold]{profile['name']}[/bold]")
+            for speaker in profile["speakers"]:
+                console.print(
+                    f"  {speaker['display_name']} ({speaker['side']}): "
+                    f"{len(speaker.get('references', []))} reference(s)"
+                )
+
+    @speakers.command("export")
+    @click.argument("profile", default="default")
+    @click.option("--output", type=click.Path(), required=True)
+    def speakers_export(profile: str, output: str):
+        """Export a profile and clips as a ZIP archive."""
+        try:
+            path = export_profile(profile, output)
+        except (FileNotFoundError, OSError, ValueError) as error:
+            raise click.ClickException(str(error)) from error
+        console.print(f"[green]Speaker profile exported:[/green] {path}")
+
+    @speakers.command("delete")
+    @click.argument("profile", default="default")
+    @click.option("--speaker", "display_name", default=None)
+    @click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+    def speakers_delete(profile: str, display_name: str | None, yes: bool):
+        """Delete one speaker or an entire private profile."""
+        target = (
+            f"speaker {display_name!r} from {profile}" if display_name else f"profile {profile!r}"
+        )
+        if not yes and not click.confirm(f"Delete {target} and its stored voice clips?"):
+            return
+        try:
+            delete_profile(profile, display_name)
+        except (FileNotFoundError, OSError, ValueError) as error:
+            raise click.ClickException(str(error)) from error
+        console.print(f"[green]Deleted {target}.[/green]")
+
+    @speakers.command("identify")
+    @click.argument("file", type=click.Path(exists=True))
+    def speakers_identify(file: str):
+        """Export unresolved candidate clips for human confirmation."""
+        try:
+            index = export_unknown_candidates(file)
+        except (FileNotFoundError, RuntimeError, ValueError) as error:
+            raise click.ClickException(str(error)) from error
+        console.print(
+            f"[green]Candidate clips exported:[/green] {index.parent}\n"
+            "Confirm one with `murmur speakers add NAME --side SIDE --clip CLIP`."
+        )
 
     @cli.command()
     @click.argument("file", type=click.Path(exists=True))
@@ -100,12 +199,7 @@ def register(cli: click.Group) -> None:
         default=None,
         help="Hugging Face token for pyannote model access.",
     )
-    @click.option(
-        "--speakers",
-        default=None,
-        help="Comma-separated speaker names to assign (e.g., 'Alice,Bob').",
-    )
-    def diarize(file: str, hf_token: str | None, speakers: str | None):
+    def diarize(file: str, hf_token: str | None):
         """Identify speakers in an audio file using pyannote-audio."""
         if not _check_dep():
             raise SystemExit(1)
@@ -119,23 +213,11 @@ def register(cli: click.Group) -> None:
             )
             raise SystemExit(1)
 
-        # Parse speaker name mapping
-        speaker_names: dict[str, str] = {}
-        if speakers:
-            for i, name in enumerate(speakers.split(",")):
-                speaker_names[f"SPEAKER_{i:02d}"] = name.strip()
-
         console.print(f"[bold]Diarizing[/bold] {file}")
-        rttm_path, diarized_txt_path, seen_speakers = _diarize_file(file, token, speaker_names)
+        rttm_path, diarized_txt_path, seen_speakers = _diarize_file(file, token)
 
         console.print(
             f"\n[bold green]Diarization saved:[/bold green] {rttm_path}"
             f"\n[bold green]Speaker timeline:[/bold green] {diarized_txt_path}"
             f"\n  Speakers found: {len(seen_speakers)}"
         )
-        if speaker_names:
-            mapped = ", ".join(
-                f"{k} -> {v}" for k, v in speaker_names.items() if k in seen_speakers
-            )
-            if mapped:
-                console.print(f"  Mapped: {mapped}")

--- a/src/murmur/plugins/transcribe.py
+++ b/src/murmur/plugins/transcribe.py
@@ -7,6 +7,7 @@ from rich.console import Console
 
 from murmur import hooks
 from murmur.artifacts import ArtifactStore
+from murmur.cloud_diarize import DEFAULT_DIARIZE_MODEL, transcribe_openai_diarized
 from murmur.cloud_transcribe import (
     DEFAULT_CHUNK_SECONDS,
     DEFAULT_OVERLAP_SECONDS,
@@ -164,6 +165,18 @@ def register(cli: click.Group) -> None:
         show_default=True,
     )
     @click.option("--prompt", default=None, help="Optional vocabulary/context prompt.")
+    @click.option(
+        "--diarize",
+        is_flag=True,
+        default=False,
+        help="Use channel-aware OpenAI speaker diarization.",
+    )
+    @click.option(
+        "--speaker-profile",
+        default="default",
+        show_default=True,
+        help="Confirmed speaker profile used for diarization anchors.",
+    )
     def transcribe(
         file: str,
         provider: str | None,
@@ -173,11 +186,15 @@ def register(cli: click.Group) -> None:
         chunk_seconds: float,
         overlap_seconds: float,
         prompt: str | None,
+        diarize: bool,
+        speaker_profile: str,
     ):
         """Transcribe audio locally or with resumable OpenAI cloud processing."""
         cfg = get_section("transcribe")
-        provider_name = provider or cfg.get("provider", "local")
+        provider_name = provider or ("openai" if diarize else cfg.get("provider", "local"))
         lang = language or cfg.get("language", "en")
+        if diarize and provider_name != "openai":
+            raise click.ClickException("--diarize requires --provider openai.")
         if provider_name == "local":
             if not _check_dep():
                 raise SystemExit(1)
@@ -185,17 +202,32 @@ def register(cli: click.Group) -> None:
             _transcribe_file(file, model_size, lang)
             return
 
-        model_name = model or cfg.get("openai_model", DEFAULT_OPENAI_MODEL)
+        model_name = model or (
+            cfg.get("diarize_model", DEFAULT_DIARIZE_MODEL)
+            if diarize
+            else cfg.get("openai_model", DEFAULT_OPENAI_MODEL)
+        )
         try:
-            result = transcribe_openai(
-                file,
-                model=model_name,
-                language=lang,
-                prompt=prompt,
-                chunk_seconds=chunk_seconds,
-                overlap_seconds=overlap_seconds,
-                resume=resume,
-            )
+            if diarize:
+                result = transcribe_openai_diarized(
+                    file,
+                    profile_name=speaker_profile,
+                    model=model_name,
+                    language=lang,
+                    chunk_seconds=chunk_seconds,
+                    overlap_seconds=overlap_seconds,
+                    resume=resume,
+                )
+            else:
+                result = transcribe_openai(
+                    file,
+                    model=model_name,
+                    language=lang,
+                    prompt=prompt,
+                    chunk_seconds=chunk_seconds,
+                    overlap_seconds=overlap_seconds,
+                    resume=resume,
+                )
         except (RuntimeError, ValueError) as error:
             raise click.ClickException(str(error)) from error
         transcript_path = ArtifactStore(file).path("transcript.md")
@@ -217,13 +249,23 @@ def register(cli: click.Group) -> None:
             lang = cfg.get("language", "en")
             console.print(f"\n[bold]Auto-transcribing[/bold] {output_path}")
             if cfg.get("provider", "local") == "openai":
-                transcribe_openai(
-                    output_path,
-                    model=cfg.get("openai_model", DEFAULT_OPENAI_MODEL),
-                    language=lang,
-                    chunk_seconds=cfg.get("chunk_seconds", DEFAULT_CHUNK_SECONDS),
-                    overlap_seconds=cfg.get("overlap_seconds", DEFAULT_OVERLAP_SECONDS),
-                )
+                if cfg.get("diarize", False):
+                    transcribe_openai_diarized(
+                        output_path,
+                        profile_name=cfg.get("speaker_profile", "default"),
+                        model=cfg.get("diarize_model", DEFAULT_DIARIZE_MODEL),
+                        language=lang,
+                        chunk_seconds=cfg.get("chunk_seconds", DEFAULT_CHUNK_SECONDS),
+                        overlap_seconds=cfg.get("overlap_seconds", DEFAULT_OVERLAP_SECONDS),
+                    )
+                else:
+                    transcribe_openai(
+                        output_path,
+                        model=cfg.get("openai_model", DEFAULT_OPENAI_MODEL),
+                        language=lang,
+                        chunk_seconds=cfg.get("chunk_seconds", DEFAULT_CHUNK_SECONDS),
+                        overlap_seconds=cfg.get("overlap_seconds", DEFAULT_OVERLAP_SECONDS),
+                    )
                 transcript_path = ArtifactStore(output_path).path("transcript.md")
                 hooks.emit(
                     "transcription_complete",

--- a/src/murmur/speaker_profiles.py
+++ b/src/murmur/speaker_profiles.py
@@ -1,0 +1,356 @@
+"""Private, reusable speaker profiles backed by confirmed reference clips."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import shutil
+import subprocess
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from murmur.artifacts import ArtifactStore, fingerprint_file
+
+PROFILE_SCHEMA_VERSION = 1
+MIN_REFERENCE_SECONDS = 2.0
+MAX_REFERENCE_SECONDS = 10.0
+SIDES = ("local", "remote", "unknown")
+
+
+def profiles_root() -> Path:
+    configured = os.environ.get("MURMUR_SPEAKER_PROFILES_DIR")
+    return (
+        Path(configured).expanduser()
+        if configured
+        else Path.home() / ".config" / "murmur" / "speaker-profiles"
+    ).resolve()
+
+
+def _safe_name(value: str, label: str) -> str:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,63}", value):
+        raise ValueError(f"{label} must use letters, numbers, dots, dashes, or underscores.")
+    return value
+
+
+def _profile_dir(profile: str) -> Path:
+    return profiles_root() / _safe_name(profile, "Profile name")
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _private_mkdir(path: Path) -> None:
+    root = profiles_root()
+    if not path.resolve().is_relative_to(root):
+        raise ValueError("Speaker profile paths must remain inside the private profile root.")
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    root.chmod(0o700)
+    current = root
+    for part in path.resolve().relative_to(root).parts:
+        current /= part
+        current.mkdir(exist_ok=True, mode=0o700)
+        current.chmod(0o700)
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    _private_mkdir(path.parent)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp")
+    try:
+        temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        temporary.chmod(0o600)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def load_profile(profile: str = "default") -> dict[str, Any]:
+    profile_path = _profile_dir(profile) / "profile.json"
+    try:
+        payload = json.loads(profile_path.read_text())
+    except FileNotFoundError:
+        return {
+            "schema_version": PROFILE_SCHEMA_VERSION,
+            "name": profile,
+            "speakers": [],
+            "created_at": _now(),
+            "updated_at": _now(),
+        }
+    except (json.JSONDecodeError, OSError) as error:
+        raise ValueError(f"Could not read speaker profile {profile}: {error}") from error
+    if not isinstance(payload, dict) or not isinstance(payload.get("speakers"), list):
+        raise ValueError(f"Speaker profile {profile} has an invalid schema.")
+    return payload
+
+
+def list_profiles() -> list[dict[str, Any]]:
+    root = profiles_root()
+    if not root.exists():
+        return []
+    profiles = []
+    for path in sorted(root.glob("*/profile.json")):
+        profiles.append(load_profile(path.parent.name))
+    return profiles
+
+
+def _probe_duration(path: Path) -> float:
+    ffprobe = shutil.which("ffprobe")
+    if ffprobe is None:
+        raise RuntimeError("ffprobe is required to validate speaker reference clips.")
+    result = subprocess.run(  # noqa: S603
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "format=duration:stream=codec_type",
+            "-of",
+            "json",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ValueError(f"Reference clip is not readable audio: {result.stderr.strip()}")
+    try:
+        payload = json.loads(result.stdout)
+        if not payload.get("streams"):
+            raise KeyError("streams")
+        return float(payload["format"]["duration"])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        raise ValueError("Reference clip does not contain a valid audio stream.") from error
+
+
+def _normalize_clip(source: Path, destination: Path) -> float:
+    if not source.is_file():
+        raise FileNotFoundError(f"Reference clip not found: {source}")
+    duration = _probe_duration(source)
+    if not MIN_REFERENCE_SECONDS <= duration <= MAX_REFERENCE_SECONDS:
+        raise ValueError(
+            f"Reference clips must be {MIN_REFERENCE_SECONDS:g}-{MAX_REFERENCE_SECONDS:g} "
+            f"seconds; received {duration:.2f} seconds."
+        )
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError("ffmpeg is required to normalize speaker reference clips.")
+    _private_mkdir(destination.parent)
+    result = subprocess.run(  # noqa: S603
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(source),
+            "-vn",
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-c:a",
+            "pcm_s16le",
+            str(destination),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Could not normalize reference clip: {result.stderr.strip()}")
+    destination.chmod(0o600)
+    return duration
+
+
+def add_speaker(
+    display_name: str,
+    *,
+    side: str,
+    clip: str | Path,
+    profile: str = "default",
+    source_recording: str | Path | None = None,
+    source_start: float | None = None,
+    source_end: float | None = None,
+) -> dict[str, Any]:
+    """Add a confirmed clip to a named speaker, creating the profile if needed."""
+    name = display_name.strip()
+    if not name:
+        raise ValueError("Display name cannot be empty.")
+    if side not in SIDES:
+        raise ValueError(f"Side must be one of: {', '.join(SIDES)}.")
+    payload = load_profile(profile)
+    source = Path(clip).expanduser().resolve()
+    speaker = next((item for item in payload["speakers"] if item["display_name"] == name), None)
+    if speaker is not None and speaker["side"] != side:
+        raise ValueError(f"{name} already belongs to side {speaker['side']} in profile {profile}.")
+    if speaker is None:
+        speaker = {
+            "id": f"speaker-{uuid4().hex[:12]}",
+            "display_name": name,
+            "side": side,
+            "references": [],
+            "created_at": _now(),
+        }
+        payload["speakers"].append(speaker)
+    reference_id = f"reference-{uuid4().hex[:12]}"
+    relative = Path("clips") / f"{speaker['id']}-{reference_id}.wav"
+    destination = _profile_dir(profile) / relative
+    duration = _normalize_clip(source, destination)
+    provenance: dict[str, Any] = {
+        "input_clip": str(source),
+        "input_fingerprint": fingerprint_file(source),
+        "confirmed_at": _now(),
+    }
+    if source_recording is not None:
+        provenance["source_recording"] = str(Path(source_recording).expanduser().resolve())
+    if source_start is not None:
+        provenance["source_start"] = source_start
+    if source_end is not None:
+        provenance["source_end"] = source_end
+    reference = {
+        "id": reference_id,
+        "path": str(relative),
+        "duration_secs": round(duration, 3),
+        "fingerprint": fingerprint_file(destination),
+        "provenance": provenance,
+    }
+    speaker["references"].append(reference)
+    speaker["updated_at"] = _now()
+    payload["updated_at"] = _now()
+    _write_json(_profile_dir(profile) / "profile.json", payload)
+    return speaker
+
+
+def reference_payload(profile: str, side: str, *, limit: int = 4) -> tuple[list[str], list[str]]:
+    """Return aligned known-speaker names and in-memory audio data URLs."""
+    payload = load_profile(profile)
+    allowed = set(SIDES) if side == "unknown" else {side}
+    names: list[str] = []
+    references: list[str] = []
+    for speaker in payload["speakers"]:
+        if speaker.get("side") not in allowed or not speaker.get("references"):
+            continue
+        reference = speaker["references"][0]
+        clip_path = _profile_dir(profile) / reference["path"]
+        if fingerprint_file(clip_path)["sha256"] != reference["fingerprint"]["sha256"]:
+            raise ValueError(f"Reference clip checksum failed for {speaker['display_name']}.")
+        encoded = base64.b64encode(clip_path.read_bytes()).decode("ascii")
+        names.append(speaker["display_name"])
+        references.append(f"data:audio/wav;base64,{encoded}")
+        if len(names) == limit:
+            break
+    return names, references
+
+
+def export_profile(profile: str, output: str | Path) -> Path:
+    """Export profile metadata and clips as a portable ZIP archive."""
+    directory = _profile_dir(profile)
+    if not (directory / "profile.json").is_file():
+        raise FileNotFoundError(f"Speaker profile not found: {profile}")
+    output_path = Path(output).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(directory.rglob("*")):
+            if path.is_file():
+                archive.write(path, path.relative_to(directory))
+    return output_path
+
+
+def delete_profile(profile: str, display_name: str | None = None) -> None:
+    """Delete one speaker and their clips, or delete the complete profile."""
+    directory = _profile_dir(profile)
+    if display_name is None:
+        if not directory.exists():
+            raise FileNotFoundError(f"Speaker profile not found: {profile}")
+        shutil.rmtree(directory)
+        return
+    payload = load_profile(profile)
+    speaker = next(
+        (item for item in payload["speakers"] if item["display_name"] == display_name), None
+    )
+    if speaker is None:
+        raise ValueError(f"Speaker not found in profile {profile}: {display_name}")
+    for reference in speaker.get("references", []):
+        (_profile_dir(profile) / reference["path"]).unlink(missing_ok=True)
+    payload["speakers"].remove(speaker)
+    payload["updated_at"] = _now()
+    _write_json(directory / "profile.json", payload)
+
+
+def export_unknown_candidates(recording: str | Path) -> Path:
+    """Export one candidate clip per unresolved diarization label for confirmation."""
+    recording_path = Path(recording).expanduser().resolve()
+    store = ArtifactStore(recording_path)
+    transcript_path = store.path("transcript.json")
+    payload = json.loads(transcript_path.read_text())
+    segments = payload.get("segments", [])
+    candidates: dict[str, dict[str, Any]] = {}
+    for segment in segments:
+        speaker = str(segment.get("speaker", ""))
+        if speaker.startswith("unknown:") and speaker not in candidates:
+            candidates[speaker] = segment
+    output_dir = store.path("speakers/candidates")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError("ffmpeg is required to export speaker candidates.")
+    index = []
+    for number, (speaker, segment) in enumerate(candidates.items(), 1):
+        output = output_dir / f"candidate-{number:03d}.wav"
+        result = subprocess.run(  # noqa: S603
+            [
+                ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-ss",
+                str(segment["start"]),
+                "-i",
+                str(recording_path),
+                "-t",
+                str(
+                    min(
+                        MAX_REFERENCE_SECONDS,
+                        max(MIN_REFERENCE_SECONDS, segment["end"] - segment["start"]),
+                    )
+                ),
+                "-map",
+                f"0:{segment.get('stream_index', 0)}",
+                "-ac",
+                "1",
+                "-ar",
+                "16000",
+                "-c:a",
+                "pcm_s16le",
+                str(output),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Could not export {speaker}: {result.stderr.strip()}")
+        index.append(
+            {
+                "speaker": speaker,
+                "side": segment.get("side", "unknown"),
+                "start": segment["start"],
+                "end": segment["end"],
+                "clip": output.name,
+            }
+        )
+    index_path = store.write_json("speakers/candidates/index.json", {"candidates": index})
+    store.register_artifact(
+        "speaker_candidates",
+        index_path,
+        kind="speaker_identity_candidates",
+        provenance={"source": str(recording_path)},
+    )
+    return index_path

--- a/tests/test_cloud_diarize.py
+++ b/tests/test_cloud_diarize.py
@@ -1,0 +1,212 @@
+"""Tests for channel-aware, identity-anchored OpenAI diarization."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from murmur.artifacts import ArtifactStore, fingerprint_file
+from murmur.cloud_diarize import (
+    Track,
+    _merge_track_segments,
+    _normalize_segments,
+    _select_tracks,
+    _submit_diarized_chunk,
+    transcribe_openai_diarized,
+)
+
+
+class FakeTranscriptions:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.requests = []
+
+    def create(self, **kwargs):
+        self.requests.append(kwargs)
+        response = next(self.responses)
+        return SimpleNamespace(model_dump=lambda mode="json": response)
+
+
+def _client(responses):
+    transcriptions = FakeTranscriptions(responses)
+    return SimpleNamespace(
+        audio=SimpleNamespace(transcriptions=transcriptions), calls=transcriptions
+    )
+
+
+def _recording(tmp_path, *, multitrack=True, duration=30):
+    recording = tmp_path / "meeting.mka"
+    recording.write_bytes(b"original recording")
+    streams = (
+        [
+            {"index": 0, "codec_type": "audio", "source_role": "mixed"},
+            {"index": 1, "codec_type": "audio", "source_role": "microphone"},
+            {"index": 2, "codec_type": "audio", "source_role": "call_output"},
+        ]
+        if multitrack
+        else [{"index": 0, "codec_type": "audio", "source_role": "mixed"}]
+    )
+    recording.with_suffix(".json").write_text(
+        json.dumps({"duration_secs": duration, "streams": streams})
+    )
+    return recording
+
+
+def _profile(root: Path):
+    directory = root / "default"
+    clips = directory / "clips"
+    clips.mkdir(parents=True)
+    local = clips / "rohan.wav"
+    remote = clips / "abby.wav"
+    local.write_bytes(b"RIFF local")
+    remote.write_bytes(b"RIFF remote")
+    payload = {
+        "schema_version": 1,
+        "name": "default",
+        "speakers": [
+            {
+                "id": "speaker-rohan",
+                "display_name": "Rohan",
+                "side": "local",
+                "references": [
+                    {
+                        "path": "clips/rohan.wav",
+                        "duration_secs": 4,
+                        "fingerprint": fingerprint_file(local),
+                    }
+                ],
+            },
+            {
+                "id": "speaker-abby",
+                "display_name": "Abby",
+                "side": "remote",
+                "references": [
+                    {
+                        "path": "clips/abby.wav",
+                        "duration_secs": 4,
+                        "fingerprint": fingerprint_file(remote),
+                    }
+                ],
+            },
+        ],
+    }
+    (directory / "profile.json").write_text(json.dumps(payload))
+
+
+def _fake_extract(recording, output, chunk, stream_index):
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(f"wav:{chunk.index}:{stream_index}".encode())
+
+
+def test_track_selection_prefers_independent_microphone_and_call_output():
+    manifest = {
+        "media": {
+            "streams": [
+                {"index": 0, "source_role": "mixed"},
+                {"index": 1, "source_role": "microphone"},
+                {"index": 2, "source_role": "call_output"},
+            ]
+        }
+    }
+    assert _select_tracks(manifest) == [Track("local", 1), Track("remote", 2)]
+
+
+def test_unknown_labels_are_chunk_scoped_and_known_names_are_anchored():
+    first = _normalize_segments(
+        {"segments": [{"speaker": "Rohan", "start": 0, "end": 2, "text": "hello"}]},
+        side="local",
+        stream_index=1,
+        chunk_index=0,
+        chunk_start=0,
+        chunk_duration=10,
+        known_names={"Rohan"},
+    )
+    second = _normalize_segments(
+        {"segments": [{"speaker": "A", "start": 0, "end": 2, "text": "unknown"}]},
+        side="local",
+        stream_index=1,
+        chunk_index=1,
+        chunk_start=8,
+        chunk_duration=10,
+        known_names={"Rohan"},
+    )
+    assert first[0]["speaker"] == "Rohan"
+    assert second[0]["speaker"] == "unknown:local:chunk-0001:A"
+
+
+def test_track_merge_deduplicates_only_within_one_timeline():
+    chunks = [
+        [{"start": 0, "end": 10, "text": "we chose the launch plan"}],
+        [{"start": 8, "end": 14, "text": "the launch plan next"}],
+    ]
+    merged = _merge_track_segments(chunks)
+    assert [segment["text"] for segment in merged] == ["we chose the launch plan", "next"]
+    assert merged[1]["start"] == 10
+
+
+def test_channel_aware_pipeline_anchors_profiles_and_preserves_overlap(tmp_path, monkeypatch):
+    profile_root = tmp_path / "profiles"
+    monkeypatch.setenv("MURMUR_SPEAKER_PROFILES_DIR", str(profile_root))
+    _profile(profile_root)
+    recording = _recording(tmp_path)
+    client = _client(
+        [
+            {"segments": [{"speaker": "Rohan", "start": 0, "end": 10, "text": "local speech"}]},
+            {
+                "segments": [
+                    {"speaker": "Abby", "start": 5, "end": 12, "text": "remote overlap"},
+                    {"speaker": "B", "start": 14, "end": 18, "text": "unknown remote"},
+                ]
+            },
+        ]
+    )
+    with patch("murmur.cloud_diarize._extract_chunk", side_effect=_fake_extract):
+        first = transcribe_openai_diarized(recording, client=client)
+        second = transcribe_openai_diarized(recording, client=client)
+
+    assert first == second
+    assert first["channel_aware"] is True
+    assert [segment["speaker"] for segment in first["segments"]] == [
+        "Rohan",
+        "Abby",
+        "unknown:remote:chunk-0000:B",
+    ]
+    assert first["segments"][0]["end"] == 10
+    assert first["segments"][1]["start"] == 5
+    assert len(client.calls.requests) == 2
+    assert client.calls.requests[0]["known_speaker_names"] == ["Rohan"]
+    assert client.calls.requests[1]["known_speaker_names"] == ["Abby"]
+    assert "data:audio" not in (ArtifactStore(recording).jobs_path.read_text())
+    assert recording.read_bytes() == b"original recording"
+
+
+def test_diarized_sdk_request_uses_auto_chunking_and_known_references(tmp_path):
+    import httpx
+    from openai import OpenAI
+
+    chunk = tmp_path / "chunk.wav"
+    chunk.write_bytes(b"RIFF fake")
+
+    def handler(request):
+        body = request.read()
+        assert b"diarized_json" in body
+        assert b'name="chunking_strategy"' in body
+        assert b"auto" in body
+        assert b'name="known_speaker_names[]"' in body
+        assert b"Rohan" in body
+        assert b'name="known_speaker_references[]"' in body
+        return httpx.Response(200, json={"segments": []})
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    client = OpenAI(
+        api_key="test-api-key", base_url="https://api.openai.test/v1", http_client=http_client
+    )
+    result = _submit_diarized_chunk(
+        client,
+        chunk,
+        model="gpt-4o-transcribe-diarize",
+        language="en",
+        known_names=["Rohan"],
+        known_references=["data:audio/wav;base64,UklGRg=="],
+    )
+    assert result["segments"] == []

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -41,6 +41,7 @@ def test_diarize_registers_command():
     grp = _make_group()
     diarize.register(grp)
     assert "diarize" in [c for c in grp.commands]
+    assert "speakers" in [c for c in grp.commands]
 
 
 def test_tui_registers_command():
@@ -72,12 +73,12 @@ def test_diarize_missing_dep():
     assert result.exit_code != 0
 
 
-def test_diarize_has_speakers_option():
+def test_diarize_does_not_offer_unsafe_cluster_order_name_mapping():
     grp = _make_group()
     diarize.register(grp)
     cmd = grp.commands["diarize"]
     param_names = [p.name for p in cmd.params]
-    assert "speakers" in param_names
+    assert "speakers" not in param_names
 
 
 def test_format_srt_time():
@@ -191,6 +192,41 @@ def test_transcribe_openai_provider_dispatches_cloud_pipeline(tmp_path):
     )
 
 
+def test_transcribe_diarize_dispatches_channel_aware_pipeline(tmp_path):
+    audio = tmp_path / "meeting.mka"
+    audio.write_bytes(b"audio")
+    grp = _make_group()
+    transcribe.register(grp)
+
+    with (
+        patch.object(
+            transcribe, "transcribe_openai_diarized", return_value={"segments": []}
+        ) as cloud,
+        patch.object(transcribe.hooks, "emit"),
+    ):
+        result = runner.invoke(
+            grp,
+            [
+                "transcribe",
+                str(audio),
+                "--diarize",
+                "--speaker-profile",
+                "team",
+            ],
+        )
+
+    assert result.exit_code == 0
+    cloud.assert_called_once_with(
+        str(audio),
+        profile_name="team",
+        model="gpt-4o-transcribe-diarize",
+        language="en",
+        chunk_seconds=600.0,
+        overlap_seconds=2.0,
+        resume=True,
+    )
+
+
 def test_diarization_persists_canonical_outputs(tmp_path):
     audio = tmp_path / "meeting.flac"
     audio.write_bytes(b"audio")
@@ -216,13 +252,11 @@ def test_diarization_persists_canonical_outputs(tmp_path):
     pyannote.audio = pyannote_audio
 
     with patch.dict(sys.modules, {"pyannote": pyannote, "pyannote.audio": pyannote_audio}):
-        rttm, timeline, speakers = diarize._diarize_file(
-            str(audio), "hf_never_persist", {"SPEAKER_00": "Rohan"}
-        )
+        rttm, timeline, speakers = diarize._diarize_file(str(audio), "hf_never_persist")
 
     assert rttm.parent.name == "speakers"
     assert "SPEAKER_00" in rttm.read_text()
-    assert "Rohan" in timeline.read_text()
+    assert "SPEAKER_00" in timeline.read_text()
     assert speakers == {"SPEAKER_00"}
     assert "hf_never_persist" not in (tmp_path / "artifacts/meeting/jobs.json").read_text()
 

--- a/tests/test_speaker_profiles.py
+++ b/tests/test_speaker_profiles.py
@@ -1,0 +1,149 @@
+"""Tests for private speaker profile lifecycle and reference validation."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from murmur.artifacts import ArtifactStore
+from murmur.speaker_profiles import (
+    add_speaker,
+    delete_profile,
+    export_profile,
+    export_unknown_candidates,
+    list_profiles,
+    load_profile,
+    reference_payload,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_profiles(tmp_path, monkeypatch):
+    monkeypatch.setenv("MURMUR_SPEAKER_PROFILES_DIR", str(tmp_path / "profiles"))
+
+
+def _fake_normalize(source: Path, destination: Path) -> float:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(b"RIFF confirmed voice")
+    return 4.0
+
+
+def test_profile_add_reference_export_and_delete(tmp_path):
+    source = tmp_path / "rohan.wav"
+    source.write_bytes(b"source audio")
+    with patch("murmur.speaker_profiles._normalize_clip", side_effect=_fake_normalize):
+        speaker = add_speaker(
+            "Rohan",
+            side="local",
+            clip=source,
+            source_recording=tmp_path / "meeting.mka",
+            source_start=12.0,
+            source_end=16.0,
+        )
+
+    assert speaker["display_name"] == "Rohan"
+    assert speaker["side"] == "local"
+    assert speaker["references"][0]["duration_secs"] == 4.0
+    assert list_profiles()[0]["name"] == "default"
+    names, references = reference_payload("default", "local")
+    assert names == ["Rohan"]
+    assert references[0].startswith("data:audio/wav;base64,")
+    assert "data:audio" not in json.dumps(load_profile("default"))
+    assert (tmp_path / "profiles").stat().st_mode & 0o777 == 0o700
+    assert (tmp_path / "profiles/default/profile.json").stat().st_mode & 0o777 == 0o600
+
+    archive = export_profile("default", tmp_path / "profile.zip")
+    assert archive.is_file()
+    delete_profile("default", "Rohan")
+    assert load_profile("default")["speakers"] == []
+    delete_profile("default")
+    assert not (tmp_path / "profiles/default").exists()
+
+
+def test_profile_rejects_side_change_for_existing_identity(tmp_path):
+    source = tmp_path / "voice.wav"
+    source.write_bytes(b"source audio")
+    with patch("murmur.speaker_profiles._normalize_clip", side_effect=_fake_normalize):
+        add_speaker("Abby", side="remote", clip=source)
+        with pytest.raises(ValueError, match="already belongs"):
+            add_speaker("Abby", side="local", clip=source)
+
+
+def test_identify_exports_one_candidate_per_unresolved_label(tmp_path):
+    recording = tmp_path / "meeting.mka"
+    recording.write_bytes(b"recording")
+    store = ArtifactStore(recording)
+    store.ensure_manifest()
+    store.write_json(
+        "transcript.json",
+        {
+            "segments": [
+                {
+                    "speaker": "unknown:local:chunk-0000:A",
+                    "side": "local",
+                    "stream_index": 1,
+                    "start": 1,
+                    "end": 5,
+                },
+                {
+                    "speaker": "unknown:local:chunk-0000:A",
+                    "side": "local",
+                    "stream_index": 1,
+                    "start": 7,
+                    "end": 9,
+                },
+                {
+                    "speaker": "unknown:remote:chunk-0000:B",
+                    "side": "remote",
+                    "stream_index": 2,
+                    "start": 3,
+                    "end": 8,
+                },
+                {"speaker": "Rohan", "start": 0, "end": 1},
+            ]
+        },
+    )
+
+    def fake_run(command, **kwargs):
+        Path(command[-1]).write_bytes(b"RIFF candidate")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with (
+        patch("murmur.speaker_profiles.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch("murmur.speaker_profiles.subprocess.run", side_effect=fake_run) as run,
+    ):
+        index = export_unknown_candidates(recording)
+
+    candidates = json.loads(index.read_text())["candidates"]
+    assert len(candidates) == 2
+    assert [candidate["side"] for candidate in candidates] == ["local", "remote"]
+    assert len(run.call_args_list) == 2
+
+
+@pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="FFmpeg integration tools are unavailable",
+)
+def test_reference_duration_is_validated_with_real_audio(tmp_path):
+    source = tmp_path / "short.wav"
+    subprocess.run(  # noqa: S603
+        [
+            str(shutil.which("ffmpeg")),
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            str(source),
+        ],
+        check=True,
+    )
+
+    with pytest.raises(ValueError, match="2-10 seconds"):
+        add_speaker("Sujata", side="remote", clip=source)


### PR DESCRIPTION
## Summary
- add private speaker profiles with 2-10 second validated/normalized references, provenance, export, and confirmed deletion controls
- add channel-aware OpenAI diarization that processes microphone and call-output tracks separately with side-relevant known speaker anchors
- merge absolute timelines without removing cross-channel overlap and preserve unknown identities as auditable chunk-local labels
- add candidate clip export for human identity confirmation and remove unsafe cluster-order name assignment
- expose `transcribe --diarize --speaker-profile` and document the Rohan/Jatan local plus Sujata/Abby remote workflow

## Verification
- `uvx --no-config ruff check .`
- `uvx --no-config ruff format --check .`
- `uv --no-config run --extra cloud --with pytest --with pytest-cov pytest` (105 passed)
- OpenAI SDK multipart request tested for `diarized_json`, automatic chunking, and aligned known speaker references
- real FFmpeg/FFprobe reference duration validation covered

Closes #23
