### PR TITLE
feat: add grounded summaries and approval-gated tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,12 @@ overlap_seconds = 2
 
 [summarize]
 auto = true          # auto-summarize after transcription
-model = "llama3"     # ollama model
-ollama_url = "http://localhost:11434"
+model = "gemini/gemini-3-flash-preview"
+max_chunk_characters = 24000
+
+[summarize.glossary]
+k8s = "Kubernetes"
+Soo-jata = "Sujata"
 
 [diarize]
 hf_token = "hf_..."  # hugging face token for pyannote
@@ -163,9 +167,13 @@ manifest.json
 jobs.json
 raw-responses/
 speakers/
-transcript.txt
+transcript.json
+transcript.cleaned.json
+transcript.cleaned.md
 transcript.srt
+summary.json
 summary.md
+tasks.preview.json
 ```
 
 Writes are atomic. Completed outputs are checksum-validated before they are
@@ -238,6 +246,40 @@ murmur speakers delete default
 `speakers identify` exports candidate clips for unresolved labels. Adding one
 of those candidates to a profile is the explicit human confirmation step.
 
+### Grounded summaries and approved tasks
+
+Summaries are generated from the canonical segment-labelled transcript. Murmur
+keeps provider output untouched, writes deterministic whitespace cleanup and
+uncertainty annotations to separate `transcript.cleaned.*` artifacts, and
+validates generated claims against real segment IDs. Unsupported claims are
+dropped into the audit trail in `summary.json` rather than presented as facts.
+
+```bash
+murmur summarize meeting.mka \
+  --glossary Soo-jata=Sujata \
+  --glossary k8s=Kubernetes
+```
+
+The Markdown output includes attendees, executive summary, topics, decisions,
+open questions, action items, and transcription uncertainties. Decisions and
+actions show whether they were explicit or inferred, confidence, source
+excerpts, and links to timestamps in `transcript.cleaned.md`. Long calls use
+map-reduce when they exceed the configured character budget. `summary.json`
+records the model, prompt version, source hash, glossary, generation time, and
+map/reduce call plan so regeneration is auditable.
+
+Task backends are never changed by extraction alone. The first command writes
+an exact, reviewable `tasks.preview.json`; a second explicit command applies
+that same preview only if its source has not changed:
+
+```bash
+murmur tasks ingest meeting.mka
+# review tasks.preview.json
+murmur tasks ingest meeting.mka --approve
+```
+
+Automatic task extraction also stops at the preview stage.
+
 ## Plugins
 
 | Plugin | Command | What it does | Install |
@@ -245,9 +287,10 @@ of those candidates to a profile is the explicit human confirmation step.
 | **watch** | `murmur watch` | Detect meeting apps using the mic, notify + auto-record | built-in |
 | **memory** | `murmur memory` | Personal context for LLM summaries | built-in |
 | **tui** | `murmur tui` | Live dashboard with artifact viewer + generation | `murmur[tui]` |
-| **summarize** | `murmur summarize <file>` | DSPy structured summarization → `.summary.md` | `murmur[ai]` |
+| **summarize** | `murmur summarize <file>` | Grounded map-reduce summary with citations | `murmur[ai]` |
 | **transcribe** | `murmur transcribe <file>` | Local or resumable OpenAI transcription | `murmur[transcribe]` / `murmur[cloud]` |
 | **diarize** | `murmur diarize <file>` | Speaker diarization → `.rttm` + `.diarized.txt` | `murmur[diarize]` |
+| **tasks** | `murmur tasks ingest <file>` | Preview and explicitly approve task changes | `murmur[tasks]` |
 
 ## Development
 
@@ -274,5 +317,6 @@ the private process in [SECURITY.md](SECURITY.md).
 
 - [x] Automatic transcription (local Whisper / OpenAI)
 - [x] Speaker diarization with confirmed identity profiles
+- [x] Grounded summaries and approval-gated action items
 - [x] Auto-detect meeting apps and start recording
 - [ ] Web UI for browsing/searching recordings

--- a/src/murmur/grounded_summary.py
+++ b/src/murmur/grounded_summary.py
@@ -1,0 +1,396 @@
+"""Grounded transcript cleanup, map-reduce orchestration, and citation validation."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from murmur.artifacts import ArtifactStore, fingerprint_file
+
+PROMPT_VERSION = 2
+DEFAULT_CHUNK_CHARACTERS = 24_000
+CLAIM_FIELDS = ("executive_summary", "topics", "decisions", "open_questions")
+UNCERTAIN_TEXT = re.compile(r"\b(?:inaudible|unclear|unintelligible)\b|\?{2,}", re.IGNORECASE)
+
+Generator = Callable[[str, str, dict[str, str]], dict[str, Any]]
+
+
+def _clock(seconds: float) -> str:
+    total = round(seconds)
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+def load_source_transcript(input_path: str | Path) -> tuple[ArtifactStore, dict[str, Any], Path]:
+    """Load canonical JSON when available, with a legacy text fallback."""
+    candidate = Path(input_path).expanduser().resolve()
+    store = ArtifactStore.for_input(candidate)
+    canonical_path = store.path("transcript.json")
+    source_path = canonical_path if canonical_path.is_file() else candidate
+    if source_path.suffix == ".json":
+        payload = json.loads(source_path.read_text())
+        if not isinstance(payload, dict) or not isinstance(payload.get("segments"), list):
+            raise ValueError(f"Transcript JSON has an invalid schema: {source_path}")
+        return store, payload, source_path
+
+    text = source_path.read_text()
+    segments = [
+        {
+            "id": f"legacy-{index:06d}",
+            "start": float(index - 1),
+            "end": float(index),
+            "speaker": "unknown",
+            "text": line.strip(),
+        }
+        for index, line in enumerate(text.splitlines(), 1)
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    return (
+        store,
+        {
+            "schema_version": 1,
+            "source": str(source_path),
+            "provider": "legacy-text",
+            "segments": segments,
+            "text": " ".join(segment["text"] for segment in segments),
+        },
+        source_path,
+    )
+
+
+def clean_transcript(source: dict[str, Any]) -> dict[str, Any]:
+    """Normalize whitespace without rewriting source words or speaker identity."""
+    cleaned = []
+    for index, source_segment in enumerate(source.get("segments", []), 1):
+        raw_text = str(source_segment.get("text", ""))
+        text = " ".join(raw_text.split())
+        if not text:
+            continue
+        speaker = str(source_segment.get("speaker") or "unknown")
+        reasons = []
+        if speaker == "unknown" or speaker.startswith("unknown:"):
+            reasons.append("unresolved_speaker")
+        if UNCERTAIN_TEXT.search(text):
+            reasons.append("uncertain_transcription")
+        cleaned.append(
+            {
+                "id": str(source_segment.get("id") or f"segment-{index:06d}"),
+                "start": round(float(source_segment.get("start", 0.0)), 3),
+                "end": round(float(source_segment.get("end", 0.0)), 3),
+                "speaker": speaker,
+                "side": source_segment.get("side", "unknown"),
+                "text": text,
+                "raw_text": raw_text,
+                "uncertain": bool(reasons),
+                "uncertainty_reasons": reasons,
+            }
+        )
+    return {
+        "schema_version": 1,
+        "kind": "cleaned_transcript",
+        "source_provider": source.get("provider"),
+        "source_model": source.get("model"),
+        "segments": cleaned,
+        "text": " ".join(segment["text"] for segment in cleaned),
+    }
+
+
+def render_cleaned_transcript(cleaned: dict[str, Any]) -> str:
+    lines = ["# Cleaned transcript", ""]
+    for segment in cleaned["segments"]:
+        marker = " ⚠" if segment["uncertain"] else ""
+        lines.extend(
+            [
+                f'<a id="{segment["id"]}"></a>',
+                f"**[{_clock(segment['start'])}] {segment['speaker']}**{marker}: "
+                f"{segment['text']}",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def persist_cleaned_transcript(
+    store: ArtifactStore, cleaned: dict[str, Any], source_path: Path
+) -> tuple[Path, Path]:
+    cleaned_payload = dict(cleaned)
+    cleaned_payload["source_transcript"] = str(source_path)
+    cleaned_payload["source_fingerprint"] = fingerprint_file(source_path)
+    json_path = store.write_json("transcript.cleaned.json", cleaned_payload)
+    markdown_path = store.write_text(
+        "transcript.cleaned.md", render_cleaned_transcript(cleaned_payload)
+    )
+    provenance = {
+        "operation": "whitespace_normalization_and_uncertainty_annotation",
+        "source_transcript": str(source_path),
+        "source_sha256": cleaned_payload["source_fingerprint"]["sha256"],
+    }
+    store.register_artifact(
+        "cleaned_transcript_json", json_path, kind="cleaned_transcript", provenance=provenance
+    )
+    store.register_artifact(
+        "cleaned_transcript_markdown",
+        markdown_path,
+        kind="cleaned_transcript_markdown",
+        provenance=provenance,
+    )
+    return json_path, markdown_path
+
+
+def _segment_text(segment: dict[str, Any]) -> str:
+    return (
+        f"[{segment['id']} {_clock(segment['start'])}-{_clock(segment['end'])}] "
+        f"{segment['speaker']}: {segment['text']}"
+    )
+
+
+def chunk_segments(
+    segments: list[dict[str, Any]], max_characters: int = DEFAULT_CHUNK_CHARACTERS
+) -> list[list[dict[str, Any]]]:
+    if max_characters < 100:
+        raise ValueError("Summary chunk size must be at least 100 characters.")
+    chunks: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] = []
+    current_size = 0
+    for segment in segments:
+        size = len(_segment_text(segment)) + 1
+        if current and current_size + size > max_characters:
+            chunks.append(current)
+            current = []
+            current_size = 0
+        current.append(segment)
+        current_size += size
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _empty_summary() -> dict[str, Any]:
+    return {
+        "title": "No source content",
+        "attendees": [],
+        "executive_summary": [],
+        "topics": [],
+        "decisions": [],
+        "open_questions": [],
+        "action_items": [],
+    }
+
+
+def _citation(segment: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "segment_id": segment["id"],
+        "start": segment["start"],
+        "end": segment["end"],
+        "timestamp": _clock(segment["start"]),
+        "speaker": segment["speaker"],
+        "excerpt": segment["text"][:240],
+        "href": f"transcript.cleaned.md#{segment['id']}",
+    }
+
+
+def _ground_item(
+    item: Any, index: dict[str, dict[str, Any]], rejected: list[dict[str, Any]], field: str
+) -> dict[str, Any] | None:
+    if isinstance(item, str):
+        item = {"text": item, "segment_ids": []}
+    if not isinstance(item, dict):
+        rejected.append({"field": field, "reason": "invalid_schema", "value": str(item)})
+        return None
+    requested = item.get("segment_ids", [])
+    valid_ids = [segment_id for segment_id in requested if segment_id in index]
+    if not valid_ids:
+        rejected.append(
+            {
+                "field": field,
+                "reason": "no_valid_source_citation",
+                "value": item.get("text") or item.get("task") or "",
+            }
+        )
+        return None
+    grounded = dict(item)
+    grounded["segment_ids"] = valid_ids
+    grounded["citations"] = [_citation(index[segment_id]) for segment_id in valid_ids]
+    if field in ("decisions", "action_items"):
+        grounded["commitment"] = (
+            item.get("commitment")
+            if item.get("commitment") in ("explicit", "inferred")
+            else "inferred"
+        )
+        try:
+            grounded["confidence"] = max(0.0, min(1.0, float(item.get("confidence", 0.5))))
+        except TypeError, ValueError:
+            grounded["confidence"] = 0.5
+    if field == "action_items":
+        grounded["source_excerpts"] = [citation["excerpt"] for citation in grounded["citations"]]
+    return grounded
+
+
+def validate_and_ground_summary(
+    candidate: dict[str, Any], cleaned: dict[str, Any]
+) -> dict[str, Any]:
+    """Drop unsupported claims and resolve every retained citation from source data."""
+    index = {segment["id"]: segment for segment in cleaned["segments"]}
+    if not index:
+        empty = _empty_summary()
+        empty["rejected_claims"] = []
+        empty["uncertainties"] = []
+        return empty
+    rejected: list[dict[str, Any]] = []
+    grounded: dict[str, Any] = {
+        "title": str(candidate.get("title") or "Meeting summary"),
+    }
+    for field in ("attendees", *CLAIM_FIELDS, "action_items"):
+        items = candidate.get(field, [])
+        if not isinstance(items, list):
+            items = []
+        grounded[field] = [
+            result
+            for item in items
+            if (result := _ground_item(item, index, rejected, field)) is not None
+        ]
+    known_attendees = {
+        item.get("name") or item.get("text")
+        for item in grounded["attendees"]
+        if item.get("name") or item.get("text")
+    }
+    for speaker in sorted({segment["speaker"] for segment in index.values()}):
+        if speaker == "unknown" or speaker.startswith("unknown:") or speaker in known_attendees:
+            continue
+        source = next(segment for segment in index.values() if segment["speaker"] == speaker)
+        grounded["attendees"].append(
+            {"name": speaker, "segment_ids": [source["id"]], "citations": [_citation(source)]}
+        )
+    grounded["uncertainties"] = [
+        {
+            "text": ", ".join(segment["uncertainty_reasons"]),
+            "segment_ids": [segment["id"]],
+            "citations": [_citation(segment)],
+        }
+        for segment in index.values()
+        if segment["uncertain"]
+    ]
+    grounded["rejected_claims"] = rejected
+    return grounded
+
+
+def generate_grounded_summary(
+    cleaned: dict[str, Any],
+    generator: Generator,
+    *,
+    glossary: dict[str, str] | None = None,
+    max_characters: int = DEFAULT_CHUNK_CHARACTERS,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Run one-pass or map-reduce generation and return summary plus run metadata."""
+    segments = cleaned["segments"]
+    chunks = chunk_segments(segments, max_characters) if segments else []
+    calls = []
+    if not chunks:
+        return validate_and_ground_summary(_empty_summary(), cleaned), {
+            "strategy": "no-source",
+            "map_calls": 0,
+            "reduce_calls": 0,
+        }
+    glossary = glossary or {}
+    if len(chunks) == 1:
+        content = "\n".join(_segment_text(segment) for segment in chunks[0])
+        candidate = generator("final", content, glossary)
+        calls.append({"stage": "final", "segment_count": len(chunks[0])})
+        strategy = "single-pass"
+        reduce_calls = 0
+    else:
+        partials = []
+        for chunk in chunks:
+            content = "\n".join(_segment_text(segment) for segment in chunk)
+            partials.append(generator("map", content, glossary))
+            calls.append({"stage": "map", "segment_count": len(chunk)})
+        reduce_calls = 0
+        while len(partials) > 1:
+            groups: list[list[dict[str, Any]]] = []
+            current: list[dict[str, Any]] = []
+            current_size = 2
+            for partial in partials:
+                partial_size = len(json.dumps(partial, sort_keys=True)) + 1
+                if current and current_size + partial_size > max_characters:
+                    groups.append(current)
+                    current = []
+                    current_size = 2
+                current.append(partial)
+                current_size += partial_size
+            if current:
+                groups.append(current)
+            if len(groups) == len(partials):
+                groups = [partials[index : index + 2] for index in range(0, len(partials), 2)]
+            reduced = []
+            for group in groups:
+                reduced.append(generator("reduce", json.dumps(group, sort_keys=True), glossary))
+                calls.append({"stage": "reduce", "partial_count": len(group)})
+                reduce_calls += 1
+            partials = reduced
+        candidate = partials[0]
+        strategy = "map-reduce"
+    return validate_and_ground_summary(candidate, cleaned), {
+        "strategy": strategy,
+        "map_calls": len(chunks) if len(chunks) > 1 else 0,
+        "reduce_calls": reduce_calls,
+        "calls": calls,
+    }
+
+
+def _cite(item: dict[str, Any]) -> str:
+    return " ".join(
+        f"[{citation['segment_id']} @ {citation['timestamp']}]({citation['href']})"
+        for citation in item.get("citations", [])
+    )
+
+
+def render_summary(summary: dict[str, Any]) -> str:
+    lines = [f"# {summary['title']}", ""]
+    sections = (
+        ("Attendees", "attendees"),
+        ("Executive summary", "executive_summary"),
+        ("Topics", "topics"),
+        ("Decisions", "decisions"),
+        ("Open questions", "open_questions"),
+    )
+    for title, field in sections:
+        lines.extend([f"## {title}", ""])
+        for item in summary.get(field, []):
+            value = item.get("name") or item.get("text") or ""
+            qualifier = ""
+            if field == "decisions":
+                qualifier = f" ({item['commitment']}, {item['confidence']:.0%})"
+            lines.append(f"- {value}{qualifier} {_cite(item)}".rstrip())
+        if not summary.get(field):
+            lines.append("- None supported by the transcript.")
+        lines.append("")
+
+    lines.extend(["## Action items", ""])
+    for item in summary.get("action_items", []):
+        owner = item.get("owner") or "Unassigned"
+        deadline = item.get("deadline") or "no stated deadline"
+        lines.append(
+            f"- **{item.get('task', '')}** - {owner}; {deadline}; "
+            f"{item['commitment']}; {item['confidence']:.0%} {_cite(item)}".rstrip()
+        )
+        for excerpt in item.get("source_excerpts", []):
+            lines.append(f"  - Source: “{excerpt}”")
+    if not summary.get("action_items"):
+        lines.append("- None supported by the transcript.")
+    lines.append("")
+
+    if summary.get("uncertainties"):
+        lines.extend(["## Transcript uncertainties", ""])
+        for item in summary["uncertainties"]:
+            lines.append(f"- {item['text']} {_cite(item)}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def generation_timestamp() -> str:
+    return datetime.now(UTC).isoformat()

--- a/src/murmur/plugins/summarize.py
+++ b/src/murmur/plugins/summarize.py
@@ -3,6 +3,7 @@
 # NOTE: no `from __future__ import annotations` — DSPy needs real type objects
 # in Signature fields, not ForwardRef strings.
 
+import json
 from datetime import UTC
 from pathlib import Path
 
@@ -10,8 +11,18 @@ import click
 from rich.console import Console
 
 from murmur import hooks
-from murmur.artifacts import ArtifactStore
+from murmur.artifacts import ArtifactStore, fingerprint_file
 from murmur.config import get_section
+from murmur.grounded_summary import (
+    DEFAULT_CHUNK_CHARACTERS,
+    PROMPT_VERSION,
+    clean_transcript,
+    generate_grounded_summary,
+    generation_timestamp,
+    load_source_transcript,
+    persist_cleaned_transcript,
+    render_summary,
+)
 
 console = Console()
 
@@ -28,6 +39,9 @@ Rules:
 - If a deadline or date is mentioned, include it.
 - Preserve technical terms and project names exactly as spoken.
 - If the transcript is unclear or low quality, note it rather than guessing.
+- Every attendee, claim, decision, question, and action item must include one or
+  more exact segment_ids from the supplied transcript. Unsupported output is discarded.
+- Label decisions and action items as explicit commitments or inferred suggestions.
 """
 
 
@@ -61,6 +75,18 @@ def _build_summarizer():
     import dspy
     import pydantic
 
+    class GroundedClaim(pydantic.BaseModel):
+        text: str = pydantic.Field(description="Factual claim supported by the source")
+        segment_ids: list[str] = pydantic.Field(description="Exact supporting segment IDs")
+
+    class Attendee(pydantic.BaseModel):
+        name: str = pydantic.Field(description="Exact participant display name")
+        segment_ids: list[str] = pydantic.Field(description="Segments where this person speaks")
+
+    class Decision(GroundedClaim):
+        commitment: str = pydantic.Field(description="explicit or inferred")
+        confidence: float = pydantic.Field(description="Grounding confidence from 0 to 1")
+
     class ActionItem(pydantic.BaseModel):
         task: str = pydantic.Field(description="What needs to be done")
         owner: str = pydantic.Field(description="Person responsible, or 'Unassigned' if unclear")
@@ -68,33 +94,36 @@ def _build_summarizer():
             default="", description="Due date if mentioned, otherwise empty"
         )
         priority: str = pydantic.Field(default="normal", description="high, normal, or low")
+        commitment: str = pydantic.Field(description="explicit or inferred")
+        confidence: float = pydantic.Field(description="Grounding confidence from 0 to 1")
+        segment_ids: list[str] = pydantic.Field(description="Exact supporting segment IDs")
 
     class MeetingSummary(pydantic.BaseModel):
         title: str = pydantic.Field(
             description="Short descriptive title for the meeting (5-10 words)"
         )
-        executive_summary: str = pydantic.Field(
-            description="2-3 sentence overview of what the meeting was about and its outcome"
+        attendees: list[Attendee] = pydantic.Field(
+            default_factory=list, description="People supported as present by speaking segments"
         )
-        key_decisions: list[str] = pydantic.Field(
+        executive_summary: list[GroundedClaim] = pydantic.Field(
             default_factory=list,
-            description="Decisions that were made, each as a concise bullet",
+            description="Two or three grounded overview claims",
+        )
+        topics: list[GroundedClaim] = pydantic.Field(
+            default_factory=list,
+            description="Important grounded topics",
+        )
+        decisions: list[Decision] = pydantic.Field(
+            default_factory=list,
+            description="Decisions made or suggestions inferred",
+        )
+        open_questions: list[GroundedClaim] = pydantic.Field(
+            default_factory=list,
+            description="Unresolved questions supported by source segments",
         )
         action_items: list[ActionItem] = pydantic.Field(
             default_factory=list,
-            description="Tasks assigned or volunteered during the meeting",
-        )
-        discussion_points: list[str] = pydantic.Field(
-            default_factory=list,
-            description="Important topics discussed, grouped logically",
-        )
-        open_questions: list[str] = pydantic.Field(
-            default_factory=list,
-            description="Unresolved questions or topics deferred to later",
-        )
-        attendees: list[str] = pydantic.Field(
-            default_factory=list,
-            description="People who spoke or were mentioned as present",
+            description="Tasks assigned, volunteered, or clearly suggested",
         )
 
     # Resolve annotations so DSPy sees real types, not ForwardRef
@@ -103,7 +132,9 @@ def _build_summarizer():
     class SummarizeTranscript(dspy.Signature):
         """Analyze a meeting transcript and produce a structured summary."""
 
-        transcript: str = dspy.InputField(desc="Raw meeting transcript text")
+        stage: str = dspy.InputField(desc="final, map, or reduce")
+        transcript: str = dspy.InputField(desc="Segment-labelled source or partial summaries")
+        glossary: str = dspy.InputField(desc="Authoritative term mappings as JSON")
         summary: MeetingSummary = dspy.OutputField(
             desc=("Structured meeting summary with decisions, action items, and discussion points")
         )
@@ -112,8 +143,8 @@ def _build_summarizer():
         def __init__(self):
             self.summarize = dspy.ChainOfThought(SummarizeTranscript)
 
-        def forward(self, transcript):
-            return self.summarize(transcript=transcript)
+        def forward(self, stage, transcript, glossary):
+            return self.summarize(stage=stage, transcript=transcript, glossary=glossary)
 
     _summarizer_cache = MeetingSummarizer()
     return _summarizer_cache
@@ -222,46 +253,13 @@ def _get_system_prompt(file_path=None):
 
 
 def _render_markdown(summary):
-    """Render a MeetingSummary to clean markdown."""
-    lines = [f"# {summary.title}", "", summary.executive_summary, ""]
-
-    if summary.attendees:
-        lines += ["## Attendees", ""]
-        lines += [f"- {a}" for a in summary.attendees]
-        lines += [""]
-
-    if summary.key_decisions:
-        lines += ["## Key Decisions", ""]
-        lines += [f"- {d}" for d in summary.key_decisions]
-        lines += [""]
-
-    if summary.action_items:
-        lines += [
-            "## Action Items",
-            "",
-            "| Task | Owner | Deadline | Priority |",
-            "|------|-------|----------|----------|",
-        ]
-        for item in summary.action_items:
-            deadline = item.deadline or "\u2014"
-            lines.append(f"| {item.task} | {item.owner} | {deadline} | {item.priority} |")
-        lines += [""]
-
-    if summary.discussion_points:
-        lines += ["## Discussion Points", ""]
-        lines += [f"- {p}" for p in summary.discussion_points]
-        lines += [""]
-
-    if summary.open_questions:
-        lines += ["## Open Questions", ""]
-        lines += [f"- {q}" for q in summary.open_questions]
-        lines += [""]
-
-    return "\n".join(lines)
+    """Render a validated grounded summary to Markdown."""
+    payload = summary.model_dump(mode="json") if hasattr(summary, "model_dump") else summary
+    return render_summary(payload)
 
 
-def _llm_generate(model, transcript, file_path=None):
-    """Run the DSPy summarizer and return rendered markdown."""
+def _llm_generate(model, stage, transcript, glossary, file_path=None):
+    """Run one DSPy map, reduce, or final generation call and return JSON."""
     import dspy
 
     _load_env()
@@ -269,18 +267,22 @@ def _llm_generate(model, transcript, file_path=None):
     dspy.configure(lm=lm, adapter=dspy.JSONAdapter())
 
     summarizer = _build_summarizer()
-    result = summarizer(transcript=transcript)
-    return _render_markdown(result.summary)
+    result = summarizer(stage=stage, transcript=transcript, glossary=json.dumps(glossary))
+    return result.summary.model_dump(mode="json")
 
 
 def _find_transcript(file_path):
-    """Given an audio or transcript file, find the transcript .txt file."""
+    """Find canonical JSON first, with derived and legacy text fallbacks."""
     file_path = Path(file_path)
-    if file_path.suffix == ".txt":
+    if file_path.suffix in (".json", ".md", ".txt"):
         return file_path
 
     store = ArtifactStore(file_path)
-    for transcript_path in (store.path("transcript.md"), store.path("transcript.txt")):
+    for transcript_path in (
+        store.path("transcript.json"),
+        store.path("transcript.md"),
+        store.path("transcript.txt"),
+    ):
         if transcript_path.exists():
             return transcript_path
 
@@ -296,38 +298,84 @@ def _find_transcript(file_path):
     raise SystemExit(1)
 
 
-def _summarize_file(transcript_path: Path, model_name: str) -> Path:
-    """Generate and persist a summary with durable job state."""
-    transcript = transcript_path.read_text()
-    if not transcript.strip():
-        raise ValueError("Transcript is empty, nothing to summarize.")
-
-    store = ArtifactStore.for_input(transcript_path)
+def _summarize_file(
+    transcript_path: Path,
+    model_name: str,
+    *,
+    glossary: dict[str, str] | None = None,
+    max_characters: int = DEFAULT_CHUNK_CHARACTERS,
+) -> Path:
+    """Generate grounded JSON/Markdown while preserving source and cleaned layers."""
+    store, source, source_path = load_source_transcript(transcript_path)
+    cleaned = clean_transcript(source)
+    cleaned_json, cleaned_markdown = persist_cleaned_transcript(store, cleaned, source_path)
+    source_fingerprint = fingerprint_file(source_path)
+    glossary = glossary or {}
+    parameters = {
+        "prompt_version": PROMPT_VERSION,
+        "source_sha256": source_fingerprint["sha256"],
+        "glossary": glossary,
+        "max_chunk_characters": max_characters,
+    }
     summary_path = store.path("summary.md")
+    summary_json_path = store.path("summary.json")
+    previous = store.jobs().get("jobs", {}).get("summarize:litellm", {})
+    compatible_resume = bool(
+        previous.get("model") == model_name and previous.get("parameters") == parameters
+    )
     _, should_run = store.begin_job(
         "summarize",
         "litellm",
         model=model_name,
-        parameters={"prompt_version": 1},
-        input_paths=[transcript_path],
-        output_paths=[summary_path],
-        output_artifacts=["summary_markdown"],
+        parameters=parameters,
+        input_paths=[source_path, cleaned_json],
+        output_paths=[summary_json_path, summary_path, cleaned_json, cleaned_markdown],
+        output_artifacts=[
+            "summary_json",
+            "summary_markdown",
+            "cleaned_transcript_json",
+            "cleaned_transcript_markdown",
+        ],
+        resume=compatible_resume,
     )
     if not should_run:
         return summary_path
 
     try:
-        summary = _llm_generate(model_name, transcript, file_path=str(transcript_path))
-        summary_path = store.write_text("summary.md", summary)
+        summary, run = generate_grounded_summary(
+            cleaned,
+            lambda stage, content, terms: _llm_generate(
+                model_name,
+                stage,
+                content,
+                terms,
+                file_path=str(source_path),
+            ),
+            glossary=glossary,
+            max_characters=max_characters,
+        )
+        generated_at = generation_timestamp()
+        provenance = {
+            "provider": "litellm",
+            "model": model_name,
+            "prompt_version": PROMPT_VERSION,
+            "source_transcript": str(source_path),
+            "source_sha256": source_fingerprint["sha256"],
+            "glossary": glossary,
+            "generated_at": generated_at,
+            "generation": run,
+        }
+        summary["metadata"] = provenance
+        summary_json_path = store.write_json("summary.json", summary)
+        summary_path = store.write_text("summary.md", render_summary(summary))
         store.register_artifact(
-            "summary_markdown",
-            summary_path,
-            kind="meeting_summary",
-            provenance={
-                "provider": "litellm",
-                "model": model_name,
-                "parameters": {"prompt_version": 1},
-            },
+            "summary_json",
+            summary_json_path,
+            kind="grounded_meeting_summary",
+            provenance=provenance,
+        )
+        store.register_artifact(
+            "summary_markdown", summary_path, kind="meeting_summary", provenance=provenance
         )
         store.complete_job("summarize", "litellm")
         return summary_path
@@ -341,6 +389,16 @@ def _summarize_file(transcript_path: Path, model_name: str) -> Path:
 # ---------------------------------------------------------------------------
 
 
+def _parse_glossary(configured, entries) -> dict[str, str]:
+    glossary = dict(configured) if isinstance(configured, dict) else {}
+    for entry in entries:
+        source, separator, canonical = entry.partition("=")
+        if not separator or not source.strip() or not canonical.strip():
+            raise click.ClickException("Glossary entries must use SPOKEN=CANONICAL format.")
+        glossary[source.strip()] = canonical.strip()
+    return glossary
+
+
 def register(cli):
     """Register the summarize command and hook."""
 
@@ -352,15 +410,25 @@ def register(cli):
         default=None,
         help=f"LLM model (default: {DEFAULT_MODEL}). Any litellm model string.",
     )
-    def summarize(file, model):
+    @click.option(
+        "--glossary",
+        "glossary_entries",
+        multiple=True,
+        help="Authoritative SPOKEN=CANONICAL term mapping (repeatable).",
+    )
+    @click.option(
+        "--max-chars",
+        type=click.IntRange(min=100),
+        default=None,
+        help="Maximum transcript characters per map call.",
+    )
+    def summarize(file, model, glossary_entries, max_chars):
         """Summarize a transcript using an LLM.
 
-        FILE can be a transcript (.txt) or an audio file — if given an audio
-        file, the command looks for a sibling .txt transcript automatically.
+        FILE can be canonical transcript JSON, derived text, or an audio file.
 
-        Uses DSPy with chain-of-thought reasoning to produce structured output:
-        title, executive summary, key decisions, action items (with owner,
-        deadline, priority), discussion points, and open questions.
+        Uses DSPy to produce a grounded, citation-validated summary with
+        attendees, topics, decisions, open questions, and action items.
 
         Requires: uv pip install murmur[ai]
         """
@@ -369,20 +437,24 @@ def register(cli):
 
         cfg = get_section("summarize")
         model_name = model or cfg.get("model", DEFAULT_MODEL)
+        glossary = _parse_glossary(cfg.get("glossary", {}), glossary_entries)
+        chunk_characters = max_chars or cfg.get("max_chunk_characters", DEFAULT_CHUNK_CHARACTERS)
 
         transcript_path = _find_transcript(file)
-        transcript = transcript_path.read_text()
-        if not transcript.strip():
-            console.print("[yellow]Transcript is empty, nothing to summarize.[/yellow]")
-            return
 
         console.print(f"[bold]Summarizing[/bold] {transcript_path} (model={model_name})")
 
-        summary_path = _summarize_file(transcript_path, model_name)
+        summary_path = _summarize_file(
+            transcript_path,
+            model_name,
+            glossary=glossary,
+            max_characters=chunk_characters,
+        )
         summary = summary_path.read_text()
 
         console.print(f"\n[bold green]Summary saved:[/bold green] {summary_path}")
         console.print(f"\n{summary}")
+        hooks.emit("summary_complete", summary_path=str(summary_path), source_file=file)
 
     # Auto-summarize on transcription_complete if configured
     cfg = get_section("summarize")
@@ -393,12 +465,19 @@ def register(cli):
                 return
             model_name = cfg.get("model", DEFAULT_MODEL)
             transcript_path = Path(transcript_path)
-            transcript = transcript_path.read_text()
-            if not transcript.strip():
-                return
 
             console.print(f"\n[bold]Auto-summarizing[/bold] {transcript_path}")
-            summary_path = _summarize_file(transcript_path, model_name)
+            summary_path = _summarize_file(
+                transcript_path,
+                model_name,
+                glossary=cfg.get("glossary", {}),
+                max_characters=cfg.get("max_chunk_characters", DEFAULT_CHUNK_CHARACTERS),
+            )
             console.print(f"[bold green]Auto-summary saved:[/bold green] {summary_path}")
+            hooks.emit(
+                "summary_complete",
+                summary_path=str(summary_path),
+                source_file=kwargs.get("audio_path"),
+            )
 
         hooks.on("transcription_complete", _auto_summarize)

--- a/src/murmur/plugins/tasks.py
+++ b/src/murmur/plugins/tasks.py
@@ -785,10 +785,10 @@ def register(cli: click.Group) -> None:
     @tasks.command()
     @click.argument("file", type=click.Path(exists=True))
     @click.option(
-        "--dry-run",
+        "--approve",
         is_flag=True,
         default=False,
-        help="Preview extracted tasks without saving.",
+        help="Apply the exact previously generated preview.",
     )
     @click.option(
         "-m",
@@ -796,23 +796,30 @@ def register(cli: click.Group) -> None:
         default=None,
         help="LLM model override. Any litellm model string.",
     )
-    def ingest(file, dry_run, model):
-        """Extract tasks from a meeting transcript or summary.
+    def ingest(file, approve, model):
+        """Preview task changes, or explicitly approve a saved preview.
 
         FILE can be a .summary.md, .txt transcript, or an audio file -- if given
         an audio file, the command looks for a sibling summary or transcript.
 
         Requires: uv pip install murmur[tasks]
         """
-        from murmur.plugins.tasks_extract import _check_dep, _extract_tasks
+        from murmur.plugins.tasks_extract import _apply_task_preview, _check_dep, _extract_tasks
+
+        if approve:
+            count = _apply_task_preview(file)
+            if count:
+                console.print(f"[bold green]{count} approved task(s) created.[/bold green]")
+            else:
+                console.print("[dim]Preview was already applied or contained no tasks.[/dim]")
+            return
 
         if not _check_dep():
             raise SystemExit(1)
 
-        mode = "DRY RUN -- " if dry_run else ""
-        console.print(f"[bold]{mode}Extracting tasks from[/bold] {file}")
+        console.print(f"[bold]Preparing task preview from[/bold] {file}")
 
-        analysis = _extract_tasks(file, model=model, dry_run=dry_run)
+        analysis = _extract_tasks(file, model=model)
 
         # Display extracted tasks
         if analysis.new_tasks:
@@ -823,6 +830,7 @@ def register(cli: click.Group) -> None:
             table.add_column("Priority", width=8)
             table.add_column("Project", style="magenta")
             table.add_column("Deadline", style="red")
+            table.add_column("Basis", style="cyan", width=9)
             table.add_column("Conf", style="dim", width=5)
 
             pri_style = {
@@ -842,6 +850,7 @@ def register(cli: click.Group) -> None:
                     f"[{style}]{extracted.priority}[/]",
                     extracted.project,
                     extracted.deadline,
+                    extracted.commitment,
                     conf,
                 )
             console.print(table)
@@ -859,12 +868,11 @@ def register(cli: click.Group) -> None:
             for b in analysis.blockers_resolved:
                 console.print(f"  [green]\u2713[/green] {b}")
 
-        # Summary
         count = len(analysis.new_tasks)
-        if dry_run:
-            console.print(f"\n[dim]Dry run: {count} task(s) found, none saved.[/dim]")
-        elif count:
-            console.print(f"\n[bold green]{count} task(s) created.[/bold green]")
+        console.print(
+            f"\n[dim]Preview saved: {count} task change(s); no backend was modified. "
+            f"Review it, then run `murmur tasks ingest {file} --approve`.[/dim]"
+        )
 
     @tasks.command()
     @click.argument("task_id")

--- a/src/murmur/plugins/tasks_extract.py
+++ b/src/murmur/plugins/tasks_extract.py
@@ -3,12 +3,15 @@
 # NOTE: no `from __future__ import annotations` — DSPy needs real type objects
 # in Signature fields, not ForwardRef strings.
 
+import hashlib
+import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import click
 from rich.console import Console
 
-from murmur.artifacts import ArtifactStore
+from murmur.artifacts import ArtifactStore, fingerprint_file
 from murmur.config import get_section
 
 console = Console()
@@ -29,6 +32,8 @@ Rules:
 - Set priority based on urgency cues (ASAP, urgent, critical = high; nice to have = low).
 - If confidence is low (ambiguous language), set confidence below 0.7.
 - Preserve technical terms and project names exactly as spoken.
+- Classify each item as an explicit commitment or inferred suggestion.
+- Include exact source segment IDs. Do not create uncited tasks.
 """
 
 
@@ -81,6 +86,10 @@ def _build_extractor():
         )
         confidence: float = pydantic.Field(
             default=1.0, description="Confidence score 0.0-1.0 for ambiguous tasks"
+        )
+        commitment: str = pydantic.Field(default="inferred", description="explicit or inferred")
+        source_segment_ids: list[str] = pydantic.Field(
+            default_factory=list, description="Exact transcript segment IDs supporting this task"
         )
 
     class MeetingTaskAnalysis(pydantic.BaseModel):
@@ -202,14 +211,21 @@ def _find_input_file(file_path):
     """
     file_path = Path(file_path)
 
-    # If it's already a summary or transcript, use it directly
-    if file_path.suffix in (".md", ".txt"):
+    # Resolve rendered canonical summaries back to grounded JSON when available.
+    if file_path.name == "summary.md":
+        canonical_json = ArtifactStore.for_input(file_path).path("summary.json")
+        if canonical_json.exists():
+            return canonical_json
+
+    # If it's already another summary or transcript, use it directly.
+    if file_path.suffix in (".json", ".md", ".txt"):
         if file_path.exists():
             return file_path
         raise click.ClickException(f"File not found: {file_path}")
 
     store = ArtifactStore(file_path)
     for canonical in (
+        store.path("summary.json"),
         store.path("summary.md"),
         store.path("transcript.md"),
         store.path("transcript.txt"),
@@ -251,14 +267,69 @@ def _format_existing_tasks(tasks):
     return "\n".join(lines)
 
 
-def _extract_tasks(file_path, model=None, dry_run=False):
-    """Extract tasks from a file using DSPy.
+def _source_segment_ids(payload):
+    found = set()
+    if isinstance(payload, dict):
+        if isinstance(payload.get("id"), str) and "text" in payload and "start" in payload:
+            found.add(payload["id"])
+        segment_id = payload.get("segment_id")
+        if isinstance(segment_id, str):
+            found.add(segment_id)
+        segment_ids = payload.get("segment_ids", [])
+        if isinstance(segment_ids, list):
+            found.update(item for item in segment_ids if isinstance(item, str))
+        for value in payload.values():
+            found.update(_source_segment_ids(value))
+    elif isinstance(payload, list):
+        for value in payload:
+            found.update(_source_segment_ids(value))
+    return found
 
-    Returns the MeetingTaskAnalysis result from DSPy.
-    """
+
+def _preview_payload(input_path, model_name, analysis, rejected_count=0):
+    tasks = [
+        {
+            "title": task.title,
+            "owner": task.owner,
+            "deadline": task.deadline,
+            "priority": task.priority,
+            "project": task.project,
+            "source_excerpt": task.source_excerpt,
+            "confidence": task.confidence,
+            "commitment": task.commitment
+            if task.commitment in ("explicit", "inferred")
+            else "inferred",
+            "source_segment_ids": list(task.source_segment_ids),
+        }
+        for task in analysis.new_tasks
+    ]
+    identity = json.dumps(
+        {"source": str(input_path), "model": model_name, "tasks": tasks},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return {
+        "schema_version": 1,
+        "kind": "task_change_preview",
+        "preview_id": hashlib.sha256(identity.encode()).hexdigest()[:16],
+        "source": str(input_path),
+        "source_fingerprint": fingerprint_file(input_path),
+        "model": model_name,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "approval_required": True,
+        "applied_at": None,
+        "new_tasks": tasks,
+        "rejected_uncited_tasks": rejected_count,
+        "blockers_raised": list(analysis.blockers_raised),
+        "blockers_resolved": list(analysis.blockers_resolved),
+    }
+
+
+def _extract_tasks(file_path, model=None):
+    """Extract and persist a reviewable preview without mutating a task backend."""
     import dspy
 
-    from murmur.plugins.tasks import Task, load_tasks, save_tasks
+    from murmur.plugins.tasks import load_tasks
 
     cfg = get_section("tasks")
     model_name = model or cfg.get("model", DEFAULT_MODEL)
@@ -282,25 +353,89 @@ def _extract_tasks(file_path, model=None, dry_run=False):
     extractor = _build_extractor()
     result = extractor(transcript=text, existing_tasks=existing_context)
     analysis = result.analysis
+    allowed_ids = set()
+    if input_path.suffix == ".json":
+        try:
+            allowed_ids = _source_segment_ids(json.loads(text))
+        except json.JSONDecodeError:
+            allowed_ids = set()
+    rejected_count = 0
+    if input_path.suffix == ".json":
+        supported = []
+        for task in analysis.new_tasks:
+            if set(task.source_segment_ids) & allowed_ids:
+                task.source_segment_ids = [
+                    segment_id
+                    for segment_id in task.source_segment_ids
+                    if segment_id in allowed_ids
+                ]
+                supported.append(task)
+            else:
+                rejected_count += 1
+        analysis.new_tasks = supported
 
-    # Save extracted tasks unless dry_run
-    if not dry_run and analysis.new_tasks:
-        for extracted in analysis.new_tasks:
-            task = Task.new(
-                extracted.title,
-                owner=extracted.owner if extracted.owner != "Unassigned" else "",
-                priority=extracted.priority
-                if extracted.priority in ("critical", "high", "normal", "low")
-                else "normal",
-                project=extracted.project,
-                deadline=extracted.deadline,
-                source_file=str(input_path),
-                tags=["murmur"],
-            )
-            all_tasks.append(task)
-        save_tasks(all_tasks)
+    store = ArtifactStore.for_input(input_path)
+    preview = _preview_payload(input_path, model_name, analysis, rejected_count)
+    preview_path = store.write_json("tasks.preview.json", preview)
+    store.register_artifact(
+        "task_change_preview",
+        preview_path,
+        kind="task_change_preview",
+        provenance={
+            "model": model_name,
+            "source_sha256": preview["source_fingerprint"]["sha256"],
+            "approval_required": True,
+        },
+    )
 
     return analysis
+
+
+def _apply_task_preview(file_path):
+    """Apply the exact persisted preview after an explicit second-step approval."""
+    from murmur.plugins.tasks import Task, load_tasks, save_tasks
+
+    input_path = _find_input_file(file_path)
+    store = ArtifactStore.for_input(input_path)
+    preview_path = store.path("tasks.preview.json")
+    try:
+        preview = json.loads(preview_path.read_text())
+    except FileNotFoundError as error:
+        raise click.ClickException(
+            "No task preview exists. Run `murmur tasks ingest FILE` first."
+        ) from error
+    if preview.get("source") != str(input_path):
+        raise click.ClickException("Task preview belongs to a different source file.")
+    current_sha = fingerprint_file(input_path)["sha256"]
+    if preview.get("source_fingerprint", {}).get("sha256") != current_sha:
+        raise click.ClickException("Source changed after preview; generate a new task preview.")
+    if preview.get("applied_at"):
+        return 0
+    all_tasks = load_tasks()
+    for proposed in preview.get("new_tasks", []):
+        task = Task.new(
+            proposed["title"],
+            owner=proposed.get("owner", "") if proposed.get("owner") != "Unassigned" else "",
+            priority=proposed.get("priority")
+            if proposed.get("priority") in ("critical", "high", "normal", "low")
+            else "normal",
+            project=proposed.get("project", ""),
+            deadline=proposed.get("deadline", ""),
+            source_file=str(input_path),
+            tags=["murmur", proposed.get("commitment", "inferred")],
+        )
+        all_tasks.append(task)
+    save_tasks(all_tasks)
+    preview["applied_at"] = datetime.now(UTC).isoformat()
+    preview["approval_required"] = False
+    preview_path = store.write_json("tasks.preview.json", preview)
+    store.register_artifact(
+        "task_change_preview",
+        preview_path,
+        kind="task_change_preview_applied",
+        provenance={"preview_id": preview["preview_id"], "approved": True},
+    )
+    return len(preview.get("new_tasks", []))
 
 
 # ---------------------------------------------------------------------------
@@ -421,6 +556,9 @@ def _write_tasks_json(file_path, analysis, updates=None):
                 "priority": t.priority,
                 "project": t.project,
                 "confidence": t.confidence,
+                "commitment": t.commitment,
+                "source_segment_ids": t.source_segment_ids,
+                "source_excerpt": t.source_excerpt,
             }
             for t in analysis.new_tasks
         ],
@@ -443,41 +581,16 @@ def _write_tasks_json(file_path, analysis, updates=None):
 
 
 def _auto_extract(summary_path, source_file=None, **_kwargs):
-    """Hook handler: auto-extract tasks from a completed summary."""
+    """Hook handler: create a task preview, never mutate a backend automatically."""
     if not _check_dep():
         return
 
     try:
         analysis = _extract_tasks(summary_path)
-
-        # Try cross-meeting matching
-        from murmur.plugins.tasks import load_tasks
-
-        existing = [t for t in load_tasks() if t.status not in ("done", "dropped")]
-        _new, updates = _match_extracted_to_existing(analysis.new_tasks, existing)
-
-        # Apply updates to existing tasks
-        if updates:
-            from murmur.plugins.tasks import save_tasks
-
-            all_tasks = load_tasks()
-            for matched, update in updates:
-                for t in all_tasks:
-                    if t.id == matched.id:
-                        if update.new_status:
-                            t.status = update.new_status
-                        if update.new_deadline:
-                            t.deadline = update.new_deadline
-                        break
-            save_tasks(all_tasks)
-
-        # Write sidecar
-        target = source_file or summary_path
-        _write_tasks_json(target, analysis, updates)
-
         console.print(
-            f"[green]Auto-extracted {len(analysis.new_tasks)} task(s)[/green] "
-            f"from {Path(summary_path).name}"
+            f"[green]Prepared {len(analysis.new_tasks)} task change(s) for review[/green] "
+            f"from {Path(summary_path).name}; run `murmur tasks ingest {summary_path} --approve` "
+            "to apply the saved preview."
         )
     except Exception as exc:
         console.print(f"[yellow]Task auto-extraction failed:[/yellow] {exc}")

--- a/tests/test_grounded_summary.py
+++ b/tests/test_grounded_summary.py
@@ -1,0 +1,150 @@
+"""Tests for transcript cleanup, grounded citation validation, and map-reduce."""
+
+from murmur.grounded_summary import (
+    clean_transcript,
+    generate_grounded_summary,
+    render_summary,
+    validate_and_ground_summary,
+)
+
+
+def _source(segments):
+    return {"provider": "openai", "model": "test", "segments": segments}
+
+
+def test_cleanup_preserves_words_and_surfaces_uncertainty():
+    cleaned = clean_transcript(
+        _source(
+            [
+                {
+                    "id": "segment-1",
+                    "start": 1,
+                    "end": 3,
+                    "speaker": "unknown:remote:chunk-0000:A",
+                    "text": "  launch   is [inaudible] Friday  ",
+                }
+            ]
+        )
+    )
+    segment = cleaned["segments"][0]
+    assert segment["text"] == "launch is [inaudible] Friday"
+    assert segment["raw_text"] == "  launch   is [inaudible] Friday  "
+    assert segment["uncertainty_reasons"] == [
+        "unresolved_speaker",
+        "uncertain_transcription",
+    ]
+
+
+def test_grounding_resolves_valid_citations_and_rejects_unsupported_claims():
+    cleaned = clean_transcript(
+        _source(
+            [
+                {
+                    "id": "segment-1",
+                    "start": 10,
+                    "end": 14,
+                    "speaker": "Rohan",
+                    "text": "I will send the launch plan Friday.",
+                }
+            ]
+        )
+    )
+    candidate = {
+        "title": "Launch planning",
+        "attendees": [{"name": "Rohan", "segment_ids": ["segment-1"]}],
+        "executive_summary": [
+            {"text": "A launch plan was discussed.", "segment_ids": ["segment-1"]}
+        ],
+        "topics": [{"text": "Unsupported budget topic", "segment_ids": []}],
+        "decisions": [
+            {
+                "text": "The plan will be sent Friday.",
+                "commitment": "explicit",
+                "confidence": 0.95,
+                "segment_ids": ["segment-1"],
+            }
+        ],
+        "open_questions": [],
+        "action_items": [
+            {
+                "task": "Send the launch plan",
+                "owner": "Rohan",
+                "deadline": "Friday",
+                "commitment": "explicit",
+                "confidence": 0.98,
+                "segment_ids": ["segment-1"],
+            }
+        ],
+    }
+    summary = validate_and_ground_summary(candidate, cleaned)
+    action = summary["action_items"][0]
+    assert action["citations"][0]["timestamp"] == "00:00:10"
+    assert action["citations"][0]["segment_id"] == "segment-1"
+    assert action["source_excerpts"] == ["I will send the launch plan Friday."]
+    assert summary["topics"] == []
+    assert summary["rejected_claims"] == [
+        {
+            "field": "topics",
+            "reason": "no_valid_source_citation",
+            "value": "Unsupported budget topic",
+        }
+    ]
+    markdown = render_summary(summary)
+    assert "transcript.cleaned.md#segment-1" in markdown
+
+
+def test_no_source_means_no_model_call_and_no_claims():
+    called = False
+
+    def generator(stage, content, glossary):
+        nonlocal called
+        called = True
+        return {"title": "hallucinated"}
+
+    summary, metadata = generate_grounded_summary(clean_transcript(_source([])), generator)
+    assert called is False
+    assert metadata["strategy"] == "no-source"
+    assert summary["decisions"] == []
+    assert summary["action_items"] == []
+
+
+def test_long_transcript_uses_map_reduce_and_retains_source_ids():
+    cleaned = clean_transcript(
+        _source(
+            [
+                {
+                    "id": f"segment-{index}",
+                    "start": index,
+                    "end": index + 1,
+                    "speaker": "Abby",
+                    "text": "discussion " * 15,
+                }
+                for index in range(4)
+            ]
+        )
+    )
+    stages = []
+
+    def generator(stage, content, glossary):
+        stages.append(stage)
+        if stage == "reduce":
+            return {
+                "title": "Long call",
+                "attendees": [],
+                "executive_summary": [
+                    {"text": "Discussion occurred.", "segment_ids": ["segment-0"]}
+                ],
+                "topics": [],
+                "decisions": [],
+                "open_questions": [],
+                "action_items": [],
+            }
+        return {"title": "Partial", "topics": []}
+
+    summary, metadata = generate_grounded_summary(
+        cleaned, generator, glossary={"K8s": "Kubernetes"}, max_characters=200
+    )
+    assert stages.count("map") == 4
+    assert stages[-1] == "reduce"
+    assert metadata["strategy"] == "map-reduce"
+    assert summary["executive_summary"][0]["segment_ids"] == ["segment-0"]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -9,7 +9,7 @@ import click
 from click.testing import CliRunner
 
 from murmur.artifacts import ArtifactStore
-from murmur.plugins import diarize, summarize, transcribe, tui
+from murmur.plugins import diarize, summarize, tasks, transcribe, tui
 from murmur.plugins.transcribe import _format_srt_time
 
 runner = CliRunner()
@@ -48,6 +48,15 @@ def test_tui_registers_command():
     grp = _make_group()
     tui.register(grp)
     assert "tui" in [c for c in grp.commands]
+
+
+def test_task_ingest_is_preview_first_with_explicit_approval():
+    grp = _make_group()
+    tasks.register(grp)
+    ingest = grp.commands["tasks"].commands["ingest"]
+    param_names = {parameter.name for parameter in ingest.params}
+    assert "approve" in param_names
+    assert "dry_run" not in param_names
 
 
 def test_transcribe_missing_dep():
@@ -269,11 +278,30 @@ def test_summary_persists_and_skips_valid_completed_output(tmp_path):
     transcript_path = store.write_text("transcript.txt", "A useful meeting transcript")
     store.register_artifact("transcript_text", transcript_path, kind="transcript")
 
-    with patch.object(summarize, "_llm_generate", return_value="# Summary") as generate:
+    candidate = {
+        "title": "Useful meeting",
+        "attendees": [],
+        "executive_summary": [
+            {"text": "The meeting was useful.", "segment_ids": ["legacy-000001"]}
+        ],
+        "topics": [],
+        "decisions": [],
+        "open_questions": [],
+        "action_items": [],
+    }
+    with patch.object(summarize, "_llm_generate", return_value=candidate) as generate:
         first = summarize._summarize_file(transcript_path, "test/model")
         second = summarize._summarize_file(transcript_path, "test/model")
 
     assert first == second == store.path("summary.md")
-    assert first.read_text() == "# Summary"
+    assert first.read_text().startswith("# Useful meeting")
     generate.assert_called_once()
     assert store.jobs()["jobs"]["summarize:litellm"]["status"] == "complete"
+    assert store.path("summary.json").is_file()
+    assert store.path("transcript.cleaned.json").is_file()
+    assert transcript_path.read_text() == "A useful meeting transcript"
+    metadata = json.loads(store.path("summary.json").read_text())["metadata"]
+    assert metadata["model"] == "test/model"
+    assert metadata["prompt_version"] == 2
+    assert metadata["source_sha256"]
+    assert metadata["generated_at"]

--- a/tests/test_task_approval.py
+++ b/tests/test_task_approval.py
@@ -1,0 +1,135 @@
+"""Tests for preview-first, explicit task approval."""
+
+import json
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import click
+import pytest
+
+from murmur.artifacts import ArtifactStore, fingerprint_file
+from murmur.plugins.tasks_extract import _apply_task_preview, _extract_tasks
+
+
+def _summary(tmp_path):
+    recording = tmp_path / "meeting.mka"
+    recording.write_bytes(b"recording")
+    store = ArtifactStore(recording)
+    store.ensure_manifest()
+    summary = store.write_json(
+        "summary.json",
+        {
+            "action_items": [
+                {
+                    "task": "Send the plan",
+                    "segment_ids": ["segment-1"],
+                    "citations": [{"segment_id": "segment-1"}],
+                }
+            ]
+        },
+    )
+    return recording, store, summary
+
+
+def _task(title, segment_ids):
+    return SimpleNamespace(
+        title=title,
+        owner="Rohan",
+        deadline="Friday",
+        priority="normal",
+        project="Launch",
+        source_excerpt="I will send the plan Friday.",
+        confidence=0.95,
+        commitment="explicit",
+        source_segment_ids=segment_ids,
+    )
+
+
+def test_extraction_writes_preview_and_filters_uncited_tasks_without_mutation(tmp_path):
+    _recording, store, summary = _summary(tmp_path)
+    analysis = SimpleNamespace(
+        new_tasks=[_task("Send the plan", ["segment-1"]), _task("Invented task", [])],
+        blockers_raised=[],
+        blockers_resolved=[],
+    )
+    fake_dspy = ModuleType("dspy")
+    fake_dspy.LM = lambda *args, **kwargs: object()
+    fake_dspy.JSONAdapter = lambda: object()
+    fake_dspy.configure = lambda **kwargs: None
+
+    def extractor(**kwargs):
+        return SimpleNamespace(analysis=analysis)
+
+    with (
+        patch.dict(sys.modules, {"dspy": fake_dspy}),
+        patch("murmur.plugins.tasks_extract._build_extractor", return_value=extractor),
+        patch("murmur.plugins.tasks.load_tasks", return_value=[]),
+        patch("murmur.plugins.tasks.save_tasks") as save,
+    ):
+        result = _extract_tasks(summary, model="test/model")
+
+    assert [task.title for task in result.new_tasks] == ["Send the plan"]
+    save.assert_not_called()
+    preview = json.loads(store.path("tasks.preview.json").read_text())
+    assert preview["approval_required"] is True
+    assert preview["rejected_uncited_tasks"] == 1
+    assert preview["new_tasks"][0]["source_segment_ids"] == ["segment-1"]
+
+
+def test_apply_requires_saved_unchanged_preview_and_is_idempotent(tmp_path):
+    _recording, store, summary = _summary(tmp_path)
+    preview = {
+        "schema_version": 1,
+        "kind": "task_change_preview",
+        "preview_id": "preview-1",
+        "source": str(summary),
+        "source_fingerprint": fingerprint_file(summary),
+        "approval_required": True,
+        "applied_at": None,
+        "new_tasks": [
+            {
+                "title": "Send the plan",
+                "owner": "Rohan",
+                "deadline": "Friday",
+                "priority": "normal",
+                "project": "Launch",
+                "commitment": "explicit",
+                "source_segment_ids": ["segment-1"],
+            }
+        ],
+    }
+    store.write_json("tasks.preview.json", preview)
+
+    with (
+        patch("murmur.plugins.tasks.load_tasks", return_value=[]),
+        patch("murmur.plugins.tasks.save_tasks") as save,
+    ):
+        assert _apply_task_preview(summary) == 1
+        assert _apply_task_preview(summary) == 0
+
+    save.assert_called_once()
+    saved_tasks = save.call_args.args[0]
+    assert saved_tasks[0].title == "Send the plan"
+    assert "explicit" in saved_tasks[0].tags
+    applied = json.loads(store.path("tasks.preview.json").read_text())
+    assert applied["approval_required"] is False
+    assert applied["applied_at"]
+
+
+def test_apply_rejects_changed_source(tmp_path):
+    _recording, store, summary = _summary(tmp_path)
+    store.write_json(
+        "tasks.preview.json",
+        {
+            "preview_id": "preview-1",
+            "source": str(summary),
+            "source_fingerprint": fingerprint_file(summary),
+            "applied_at": None,
+            "new_tasks": [],
+        },
+    )
+    summary.write_text('{"changed": true}')
+
+    with pytest.raises(click.ClickException, match="Source changed"):
+        _apply_task_preview(summary)


### PR DESCRIPTION
## Summary
- preserve canonical transcript input and create separate deterministic cleaned JSON/Markdown with uncertainty annotations
- generate attendee, executive summary, topic, decision, open-question, and action-item schemas with segment citations
- validate all retained claims against real source segment IDs, derive timestamps/excerpts locally, and audit rejected unsupported claims
- use bounded hierarchical map-reduce for long transcripts and persist model, prompt version, source hash, glossary, generation time, and call plan
- make task extraction preview-only by default; apply the exact unchanged preview only through a second explicit `--approve` command
- stop automatic task extraction at the preview stage

## Verification
- `uvx --no-config ruff check .`
- `uvx --no-config ruff format --check .`
- `uv --no-config run --extra cloud --with pytest --with pytest-cov pytest` (113 passed)
- real `murmur[ai]` environment successfully builds both DSPy schemas
- CLI help verified for glossary/map sizing and two-step task approval

Closes #24
