### PR TITLE
docs: complete community health audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,13 @@ make fix           # ruff check --fix
 ```
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the small
-issue → branch → draft PR → CI workflow. Please report vulnerabilities using
-the private process in [SECURITY.md](SECURITY.md).
+issue → branch → draft PR → CI workflow, and follow the
+[Code of Conduct](CODE_OF_CONDUCT.md). Please report vulnerabilities using the
+private process in [SECURITY.md](SECURITY.md).
+
+No license has been selected yet. The explicit decision is deferred in
+[#33](https://github.com/rororowyourboat/murmur/issues/33); no reuse license
+should be inferred until the maintainer chooses one.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- link the Code of Conduct directly from the README
- document the deliberately deferred license decision in #33
- avoid implying reuse rights before the maintainer explicitly selects a license

## Verification
- `uvx --no-config ruff check .`
- `uvx --no-config ruff format --check .`
- `uv --no-config run --extra cloud --with pytest --with pytest-cov pytest` (113 passed)

Closes #25